### PR TITLE
improve(bub-codex): support comma command

### DIFF
--- a/packages/bub-codex/src/bub_codex/plugin.py
+++ b/packages/bub-codex/src/bub_codex/plugin.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 from bub import hookimpl
 from bub.types import State
@@ -9,6 +10,9 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from bub_codex.utils import with_bub_skills
+
+if TYPE_CHECKING:
+    from bub.builtin.agent import Agent
 
 THREADS_FILE = ".bub-codex-threads.json"
 
@@ -55,8 +59,28 @@ class CodexSettings(BaseSettings):
 codex_settings = CodexSettings()
 
 
+def _runtime_agent_from_state(state: State) -> Agent | None:
+    agent = state.get("_runtime_agent")
+    if agent is None:
+        return None
+    return cast("Agent", agent)
+
+
+async def _run_internal_command(prompt: str, session_id: str, state: State) -> str | None:
+    if not prompt.strip().startswith(","):
+        return None
+    agent = _runtime_agent_from_state(state)
+    if agent is None:
+        return None
+    return await agent.run(session_id=session_id, prompt=prompt, state=state)
+
+
 @hookimpl
 async def run_model(prompt: str, session_id: str, state: State) -> str:
+    internal_command_result = await _run_internal_command(prompt, session_id, state)
+    if internal_command_result is not None:
+        return internal_command_result
+
     workspace = workspace_from_state(state)
     thread_id = _load_thread_id(session_id, state)
     command = ["codex", "e"]

--- a/packages/bub-codex/tests/test_plugin.py
+++ b/packages/bub-codex/tests/test_plugin.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+import pytest
+
+from bub_codex import plugin
+
+
+class FakeAgent:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, object]]] = []
+
+    async def run(
+        self, *, session_id: str, prompt: str, state: dict[str, object]
+    ) -> str:
+        self.calls.append((session_id, prompt, state))
+        return "internal-command-result"
+
+
+def test_run_model_delegates_internal_commands_to_runtime_agent() -> None:
+    state: dict[str, object] = {"_runtime_agent": FakeAgent()}
+
+    result = asyncio.run(plugin.run_model(",help", session_id="session-1", state=state))
+
+    agent = state["_runtime_agent"]
+    assert result == "internal-command-result"
+    assert isinstance(agent, FakeAgent)
+    assert agent.calls == [("session-1", ",help", state)]
+
+
+def test_run_model_uses_codex_for_normal_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[tuple[object, ...], str | None]] = []
+
+    class FakeProcess:
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return (b"codex-output\n", b"")
+
+    async def fake_create_subprocess_exec(*args, stdout=None, cwd=None):
+        calls.append((args, cwd))
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(plugin, "with_bub_skills", lambda workspace: contextlib.nullcontext())
+
+    state = {"_runtime_workspace": str(tmp_path)}
+    result = asyncio.run(plugin.run_model("hello", session_id="session-2", state=state))
+
+    assert result == "codex-output\n"
+    assert calls
+    args, cwd = calls[0]
+    assert args[:2] == ("codex", "e")
+    assert args[-1] == "hello"
+    assert cwd == str(tmp_path)


### PR DESCRIPTION
```
--------
workdir: /home/psiace/bubbuild/bub-playground
model: gpt-5.4
provider: openai
approval: never
sandbox: workspace-write [workdir, /tmp, $TMPDIR, /home/psiace/.codex/memories]
reasoning effort: high
reasoning summaries: none
session id: 019cc916-3a89-7d42-984e-473f4759271c
--------
user
"channel": "$cli", "chat_id": "local"
---
hello
mcp startup: no servers
⠦ Processing...codex
你好。有什么需要我处理的？
⠧ Processing...tokens used
6,142
╭──────────────────────────────────────────────────────────────────────── Assistant ─────────────────────────────────────────────────────────────────────────╮
│ 你好。有什么需要我处理的？                                                                                                                                 │
│                                                                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
bub-playground > ,tape.info
2026-03-08 00:16:51.577 | INFO     | bub.tools:_log_tool_call:80 - tool.call.start name=tape.info
2026-03-08 00:16:51.577 | INFO     | bub.tools:wrapped:38 - tool.call.success name=tape.info elapsed_time=0.55ms
2026-03-08 00:16:51.578 | INFO     | bub.builtin.store:fork:73 - Merged 1 entries into tape "91b8223128f62cfe__065943a03cbe6395"
╭───────────────────────────────────────────────────────────────────────── Command ──────────────────────────────────────────────────────────────────────────╮
│ name: 91b8223128f62cfe__065943a03cbe6395                                                                                                                   │
│ entries: 4                                                                                                                                                 │
│ anchors: 1                                                                                                                                                 │
│ last_anchor: session/start                                                                                                                                 │
│ entries_since_last_anchor: 3                                                                                                                               │
│ last_token_usage: None                                                                                                                                     │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
bub-playground >
```