### PR TITLE
feat: add bub qq channel adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.py[cod]
+.pytest_cache/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Contrib packages for the `bub` ecosystem.
 | `packages/bub-tapestore-sqlite`     | `tapestore-sqlite`     | Provides a SQLite-backed tape store for Bub conversation history.                                                                         |
 | `packages/bub-discord`              | `discord`              | Provides a Discord channel adapter for Bub message IO.                                                                                    |
 | `packages/bub-dingtalk`             | `dingtalk`             | Provides a DingTalk Stream Mode channel adapter for Bub message IO.                                                                       |
+| `packages/bub-qq`                   | `qq`                   | Provides a QQ Open Platform channel adapter for Bub message IO.                                                                           |
 | `packages/bub-web-search`           | `web-search`           | Provides a `web.search` tool backed by the Ollama web search API. Registers the tool only when `BUB_SEARCH_OLLAMA_API_KEY` is configured. |
 | `packages/bub-feishu`               | `feishu`               | Provides a Feishu channel adapter for Bub message IO.                                                                                     |
 | `packages/bub-session-prompt`       | `session-prompt`       | Provides a session-specific system prompt sourced from `~/.bub/sessions/<session_id>/AGENTS.md`.                                          |

--- a/packages/bub-qq/README.md
+++ b/packages/bub-qq/README.md
@@ -1,0 +1,80 @@
+# bub-qq
+
+QQ Open Platform channel adapter for `bub`.
+
+## Status
+
+This package is under active integration.
+
+Implemented today:
+
+- QQ Open Platform config loading via `BUB_QQ_*` environment variables
+- Access token acquisition from `https://bots.qq.com/app/getAppAccessToken`
+- Cached token refresh with the official `60` second renewal window
+- A reusable `httpx`-based OpenAPI client that injects `Authorization: QQBot {ACCESS_TOKEN}`
+- Embedded `http-webhook` receiver with callback validation (`op = 13`)
+- QQ callback validation signature generation using the documented ed25519 seed derivation flow
+- Webhook request signature verification using `X-Signature-Ed25519` and `X-Signature-Timestamp`
+- Receive transport switch: `webhook` or `websocket`
+- `C2C_MESSAGE_CREATE` parsing and Bub `ChannelMessage` adaptation for single-chat inbound events
+- Inbound `msg_id` dedupe cache to avoid duplicate passive replies on repeated deliveries
+- C2C text replies through `POST /v2/users/{openid}/messages` using passive reply `msg_id + msg_seq`
+- OpenAPI failures now expose HTTP status, platform business code, and `X-Tps-trace-ID`
+- OpenAPI known error codes now live in a dedicated catalog module with category and retryability metadata
+- WebSocket close codes now distinguish fatal stop conditions from reconnectable conditions
+
+Not implemented yet:
+
+- QQ group / channel / DM send APIs
+- Full event-specific ACK semantics beyond basic `{"op":12}` callback acknowledgement
+- Group and other QQ event types
+- WebSocket resume / shard orchestration beyond the minimal single-connection flow
+
+## Confirmed Interface Rules
+
+Based on the official QQ Bot docs for "接口调用与鉴权":
+
+- Token endpoint: `POST https://bots.qq.com/app/getAppAccessToken`
+- Request body fields: `appId`, `clientSecret`
+- Token lifetime: up to `7200` seconds
+- Renewal rule: when the current token is within `60` seconds of expiry, requesting again returns a new token while the old token remains valid during that `60` second overlap
+- OpenAPI base URL: `https://api.sgroup.qq.com`
+- Required auth header for OpenAPI requests: `Authorization: QQBot {ACCESS_TOKEN}`
+- OpenAPI trace header: `X-Tps-trace-ID`
+
+Based on the official QQ Bot docs for "事件订阅与通知":
+
+- Webhook callbacks must use HTTPS in production
+- Allowed callback ports are `80`, `443`, `8080`, `8443`
+- Validation requests arrive with `op = 13`
+- Validation response must include `plain_token` and an ed25519 signature over `event_ts + plain_token`
+- Normal webhook requests are verified against `timestamp + raw_body`
+- Normal event pushes use the shared payload shape `{id, op, d, s, t}`
+- `C2C_MESSAGE_CREATE` belongs to `GROUP_AND_C2C_EVENT (1 << 25)`
+- `C2C_MESSAGE_CREATE.d` currently maps these documented fields: `id`, `author.user_openid`, `content`, `timestamp`, `attachments`
+- Bub session ID format for C2C is `qq:c2c:<user_openid>`
+- Bub chat ID format for C2C is `c2c:<user_openid>`
+- C2C outbound currently sends text with `msg_type = 0`
+- C2C outbound uses passive reply only; active push is intentionally not used because the official doc states it stopped being provided on April 21, 2025
+- `websocket` mode currently uses `GROUP_AND_C2C_EVENT (1 << 25)` by default
+- WebSocket close codes `4914` and `4915` are treated as fatal stop conditions
+- WebSocket close codes such as `4006`, `4007`, `4008`, `4009`, and `4900~4913` are treated as reconnectable
+
+## Environment Variables
+
+- `BUB_QQ_APPID`: QQ bot app ID
+- `BUB_QQ_SECRET`: QQ bot secret
+- `BUB_QQ_TOKEN_URL`: override token endpoint if needed
+- `BUB_QQ_OPENAPI_BASE_URL`: override OpenAPI base URL if needed
+- `BUB_QQ_TIMEOUT_SECONDS`: HTTP timeout for token and OpenAPI requests
+- `BUB_QQ_TOKEN_REFRESH_SKEW_SECONDS`: token refresh lead time, defaults to `60`
+- `BUB_QQ_RECEIVE_MODE`: `webhook` or `websocket`, defaults to `webhook`
+- `BUB_QQ_WEBHOOK_HOST`: embedded webhook bind host, defaults to `127.0.0.1`
+- `BUB_QQ_WEBHOOK_PORT`: embedded webhook bind port, defaults to `9009`
+- `BUB_QQ_WEBHOOK_PATH`: webhook path, defaults to `/qq/webhook`
+- `BUB_QQ_WEBHOOK_CALLBACK_TIMEOUT_SECONDS`: max time to wait for async event handling before returning HTTP 500
+- `BUB_QQ_VERIFY_SIGNATURE`: whether to enforce webhook request signature validation, defaults to `true`
+- `BUB_QQ_INBOUND_DEDUPE_SIZE`: recent `msg_id` cache size, defaults to `1024`
+- `BUB_QQ_WEBSOCKET_INTENTS`: websocket identify intents, defaults to `1 << 25`
+- `BUB_QQ_WEBSOCKET_USE_SHARD_GATEWAY`: whether to call `/gateway/bot`, defaults to `false`
+- `BUB_QQ_WEBSOCKET_RECONNECT_DELAY_SECONDS`: reconnect delay after websocket disconnect, defaults to `5`

--- a/packages/bub-qq/README.md
+++ b/packages/bub-qq/README.md
@@ -19,16 +19,21 @@ Implemented today:
 - `C2C_MESSAGE_CREATE` parsing and Bub `ChannelMessage` adaptation for single-chat inbound events
 - Inbound `msg_id` dedupe cache to avoid duplicate passive replies on repeated deliveries
 - C2C text replies through `POST /v2/users/{openid}/messages` using passive reply `msg_id + msg_seq`
+- Standard Bub outbound routing for normal QQ text replies
+- In-memory idempotency for repeated sends on the same `session_id + msg_id`
 - OpenAPI failures now expose HTTP status, platform business code, and `X-Tps-trace-ID`
 - OpenAPI known error codes now live in a dedicated catalog module with category and retryability metadata
 - WebSocket close codes now distinguish fatal stop conditions from reconnectable conditions
+- WebSocket shard orchestration using `/gateway/bot` recommended shard count
+- Per-shard websocket session state for reconnect and resume
+- Identify pacing based on `session_start_limit.max_concurrency`
 
 Not implemented yet:
 
 - QQ group / channel / DM send APIs
-- Full event-specific ACK semantics beyond basic `{"op":12}` callback acknowledgement
+- Full event-specific webhook acknowledgement handling beyond basic `{"op":12}` receive acknowledgement
 - Group and other QQ event types
-- WebSocket resume / shard orchestration beyond the minimal single-connection flow
+- Dynamic shard rebalancing or in-process shard-count refresh after startup
 
 ## Confirmed Interface Rules
 
@@ -62,19 +67,24 @@ Based on the official QQ Bot docs for "事件订阅与通知":
 
 ## Environment Variables
 
+Required:
+
 - `BUB_QQ_APPID`: QQ bot app ID
 - `BUB_QQ_SECRET`: QQ bot secret
-- `BUB_QQ_TOKEN_URL`: override token endpoint if needed
-- `BUB_QQ_OPENAPI_BASE_URL`: override OpenAPI base URL if needed
-- `BUB_QQ_TIMEOUT_SECONDS`: HTTP timeout for token and OpenAPI requests
-- `BUB_QQ_TOKEN_REFRESH_SKEW_SECONDS`: token refresh lead time, defaults to `60`
-- `BUB_QQ_RECEIVE_MODE`: `webhook` or `websocket`, defaults to `webhook`
-- `BUB_QQ_WEBHOOK_HOST`: embedded webhook bind host, defaults to `127.0.0.1`
-- `BUB_QQ_WEBHOOK_PORT`: embedded webhook bind port, defaults to `9009`
-- `BUB_QQ_WEBHOOK_PATH`: webhook path, defaults to `/qq/webhook`
-- `BUB_QQ_WEBHOOK_CALLBACK_TIMEOUT_SECONDS`: max time to wait for async event handling before returning HTTP 500
-- `BUB_QQ_VERIFY_SIGNATURE`: whether to enforce webhook request signature validation, defaults to `true`
-- `BUB_QQ_INBOUND_DEDUPE_SIZE`: recent `msg_id` cache size, defaults to `1024`
-- `BUB_QQ_WEBSOCKET_INTENTS`: websocket identify intents, defaults to `1 << 25`
-- `BUB_QQ_WEBSOCKET_USE_SHARD_GATEWAY`: whether to call `/gateway/bot`, defaults to `false`
-- `BUB_QQ_WEBSOCKET_RECONNECT_DELAY_SECONDS`: reconnect delay after websocket disconnect, defaults to `5`
+
+Optional:
+
+- `BUB_QQ_TOKEN_URL`: override token endpoint if needed; defaults to `https://bots.qq.com/app/getAppAccessToken`
+- `BUB_QQ_OPENAPI_BASE_URL`: override OpenAPI base URL if needed; defaults to `https://api.sgroup.qq.com`
+- `BUB_QQ_TIMEOUT_SECONDS`: HTTP timeout for token and OpenAPI requests; defaults to `30`
+- `BUB_QQ_TOKEN_REFRESH_SKEW_SECONDS`: token refresh lead time; defaults to `60`
+- `BUB_QQ_RECEIVE_MODE`: `webhook` or `websocket`; defaults to `webhook`
+- `BUB_QQ_WEBHOOK_HOST`: embedded webhook bind host; defaults to `127.0.0.1`
+- `BUB_QQ_WEBHOOK_PORT`: embedded webhook bind port; defaults to `9009`
+- `BUB_QQ_WEBHOOK_PATH`: webhook path; defaults to `/qq/webhook`
+- `BUB_QQ_WEBHOOK_CALLBACK_TIMEOUT_SECONDS`: reserved for future callback handling controls; defaults to `15`
+- `BUB_QQ_VERIFY_SIGNATURE`: whether to enforce webhook request signature validation; defaults to `true`
+- `BUB_QQ_INBOUND_DEDUPE_SIZE`: recent `msg_id` cache size; defaults to `1024`
+- `BUB_QQ_WEBSOCKET_INTENTS`: websocket identify intents; defaults to `1 << 25`
+- `BUB_QQ_WEBSOCKET_USE_SHARD_GATEWAY`: whether to call `/gateway/bot` and start the recommended number of shard connections; defaults to `false`
+- `BUB_QQ_WEBSOCKET_RECONNECT_DELAY_SECONDS`: reconnect delay after websocket disconnect; defaults to `5`

--- a/packages/bub-qq/README.md
+++ b/packages/bub-qq/README.md
@@ -2,6 +2,20 @@
 
 QQ Open Platform channel adapter for `bub`.
 
+## Usage
+
+Install from the monorepo package directory during local development:
+
+```bash
+uv add --editable /path/to/bub-contrib/packages/bub-qq
+```
+
+Install directly from GitHub:
+
+```bash
+uv pip install "git+https://github.com/bubbuild/bub-contrib.git#subdirectory=packages/bub-qq"
+```
+
 ## Official Documentation
 
 For QQ bot setup, application creation, credential management, and API details, see the official QQ Bot documentation:
@@ -19,9 +33,9 @@ QQ currently treats Webhook and WebSocket callbacks as mutually exclusive receiv
 
 ## Status
 
-This package is under active integration.
+This package currently provides a working QQ Open Platform channel integration for Bub, focused on C2C message receive and reply flows.
 
-Implemented today:
+Current coverage:
 
 - QQ Open Platform config loading via `BUB_QQ_*` environment variables
 - Access token acquisition from `https://bots.qq.com/app/getAppAccessToken`
@@ -42,11 +56,12 @@ Implemented today:
 - WebSocket shard orchestration using `/gateway/bot` recommended shard count
 - Per-shard websocket session state for reconnect and resume
 - Identify pacing based on `session_start_limit.max_concurrency`
+- Automated test coverage for config, auth, signatures, channel behavior, webhook flow, websocket flow, gateway handling, and C2C services
 
-Not implemented yet:
+Current limitations:
 
 - QQ group / channel / DM send APIs
-- Full event-specific webhook acknowledgement handling beyond basic `{"op":12}` receive acknowledgement
+- Broader webhook event coverage beyond validation and the current basic `{"op":12}` acknowledgement flow
 - Group and other QQ event types
 - Dynamic shard rebalancing or in-process shard-count refresh after startup
 

--- a/packages/bub-qq/README.md
+++ b/packages/bub-qq/README.md
@@ -11,7 +11,7 @@ Implemented today:
 - QQ Open Platform config loading via `BUB_QQ_*` environment variables
 - Access token acquisition from `https://bots.qq.com/app/getAppAccessToken`
 - Cached token refresh with the official `60` second renewal window
-- A reusable `httpx`-based OpenAPI client that injects `Authorization: QQBot {ACCESS_TOKEN}`
+- A reusable `aiohttp`-based OpenAPI client that injects `Authorization: QQBot {ACCESS_TOKEN}`
 - Embedded `http-webhook` receiver with callback validation (`op = 13`)
 - QQ callback validation signature generation using the documented ed25519 seed derivation flow
 - Webhook request signature verification using `X-Signature-Ed25519` and `X-Signature-Timestamp`

--- a/packages/bub-qq/README.md
+++ b/packages/bub-qq/README.md
@@ -2,6 +2,21 @@
 
 QQ Open Platform channel adapter for `bub`.
 
+## Official Documentation
+
+For QQ bot setup, application creation, credential management, and API details, see the official QQ Bot documentation:
+
+- [QQ Bot Developer Documentation](https://bot.q.qq.com/wiki/develop/api-v2/)
+
+You will typically need the official docs to locate or configure:
+
+- `APPID`
+- `SECRET`
+- Event subscription and callback settings
+- WebSocket and OpenAPI behavior
+
+QQ currently treats Webhook and WebSocket callbacks as mutually exclusive receive modes. According to the QQ bot configuration page, after a valid HTTPS callback URL is configured successfully, WebSocket callback delivery is no longer supported. This plugin therefore requires an explicit `BUB_QQ_RECEIVE_MODE` so runtime behavior matches the platform-side configuration.
+
 ## Status
 
 This package is under active integration.
@@ -37,7 +52,7 @@ Not implemented yet:
 
 ## Confirmed Interface Rules
 
-Based on the official QQ Bot docs for "接口调用与鉴权":
+Based on the official QQ Bot docs for "API Calls and Authentication":
 
 - Token endpoint: `POST https://bots.qq.com/app/getAppAccessToken`
 - Request body fields: `appId`, `clientSecret`
@@ -47,10 +62,11 @@ Based on the official QQ Bot docs for "接口调用与鉴权":
 - Required auth header for OpenAPI requests: `Authorization: QQBot {ACCESS_TOKEN}`
 - OpenAPI trace header: `X-Tps-trace-ID`
 
-Based on the official QQ Bot docs for "事件订阅与通知":
+Based on the official QQ Bot docs for "Event Subscription and Notifications":
 
 - Webhook callbacks must use HTTPS in production
 - Allowed callback ports are `80`, `443`, `8080`, `8443`
+- After a valid HTTPS callback URL is configured successfully, WebSocket callback delivery is no longer supported
 - Validation requests arrive with `op = 13`
 - Validation response must include `plain_token` and an ed25519 signature over `event_ts + plain_token`
 - Normal webhook requests are verified against `timestamp + raw_body`
@@ -71,6 +87,12 @@ Required:
 
 - `BUB_QQ_APPID`: QQ bot app ID
 - `BUB_QQ_SECRET`: QQ bot secret
+- `BUB_QQ_RECEIVE_MODE`: inbound transport mode, must be `webhook` or `websocket`
+
+`BUB_QQ_RECEIVE_MODE` controls which receive transport the plugin starts:
+
+- `webhook`: starts the embedded webhook server only; WebSocket is not started
+- `websocket`: starts the WebSocket client only; the embedded webhook server is not started
 
 Optional:
 
@@ -78,9 +100,8 @@ Optional:
 - `BUB_QQ_OPENAPI_BASE_URL`: override OpenAPI base URL if needed; defaults to `https://api.sgroup.qq.com`
 - `BUB_QQ_TIMEOUT_SECONDS`: HTTP timeout for token and OpenAPI requests; defaults to `30`
 - `BUB_QQ_TOKEN_REFRESH_SKEW_SECONDS`: token refresh lead time; defaults to `60`
-- `BUB_QQ_RECEIVE_MODE`: `webhook` or `websocket`; defaults to `webhook`
 - `BUB_QQ_WEBHOOK_HOST`: embedded webhook bind host; defaults to `127.0.0.1`
-- `BUB_QQ_WEBHOOK_PORT`: embedded webhook bind port; defaults to `9009`
+- `BUB_QQ_WEBHOOK_PORT`: embedded webhook bind port; defaults to `8080`. QQ currently allows callback ports `80`, `443`, `8080`, and `8443`
 - `BUB_QQ_WEBHOOK_PATH`: webhook path; defaults to `/qq/webhook`
 - `BUB_QQ_WEBHOOK_CALLBACK_TIMEOUT_SECONDS`: reserved for future callback handling controls; defaults to `15`
 - `BUB_QQ_VERIFY_SIGNATURE`: whether to enforce webhook request signature validation; defaults to `true`

--- a/packages/bub-qq/pyproject.toml
+++ b/packages/bub-qq/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "bub-qq"
+version = "0.1.0"
+description = "QQ Open Platform channel for Bub"
+readme = "README.md"
+authors = [
+    { name = "wzhongyun", email= "wzhongyun@outlook.com" }
+]
+requires-python = ">=3.12"
+dependencies = [
+    "aiohttp>=3.13.3",
+    "cryptography>=45.0.0",
+    "httpx>=0.28.1",
+    "pydantic-settings>=2.10.1",
+]
+
+[project.entry-points.bub]
+qq = "bub_qq.plugin"
+
+[build-system]
+requires = ["uv_build>=0.10.4,<0.11.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = ["bub_qq", "skills.qq"]
+source-include = ["src/skills/qq/SKILL.md", "src/skills/qq/scripts/*.py"]

--- a/packages/bub-qq/pyproject.toml
+++ b/packages/bub-qq/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.13.3",
     "cryptography>=45.0.0",
-    "httpx>=0.28.1",
     "pydantic-settings>=2.10.1",
 ]
 

--- a/packages/bub-qq/src/bub_qq/__init__.py
+++ b/packages/bub-qq/src/bub_qq/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .auth import QQTokenProvider
+from .channel import QQChannel
+from .config import QQConfig
+from .gateway import QQGatewayInfo
+from .models import QQC2CMessage
+from .openapi import QQOpenAPI
+from .openapi_errors import QQOpenAPIError
+from .webhook import QQWebhookServer
+from .websocket import QQWebSocketClient
+
+__all__ = [
+    "QQChannel",
+    "QQConfig",
+    "QQGatewayInfo",
+    "QQOpenAPI",
+    "QQOpenAPIError",
+    "QQTokenProvider",
+    "QQWebhookServer",
+    "QQWebSocketClient",
+    "QQC2CMessage",
+]

--- a/packages/bub-qq/src/bub_qq/__init__.py
+++ b/packages/bub-qq/src/bub_qq/__init__.py
@@ -4,6 +4,7 @@ from .auth import QQTokenProvider
 from .channel import QQChannel
 from .config import QQConfig
 from .gateway import QQGatewayInfo
+from .gateway import QQSessionStartLimit
 from .models import QQC2CMessage
 from .openapi import QQOpenAPI
 from .openapi_errors import QQOpenAPIError
@@ -16,6 +17,7 @@ __all__ = [
     "QQGatewayInfo",
     "QQOpenAPI",
     "QQOpenAPIError",
+    "QQSessionStartLimit",
     "QQTokenProvider",
     "QQWebhookServer",
     "QQWebSocketClient",

--- a/packages/bub-qq/src/bub_qq/auth.py
+++ b/packages/bub-qq/src/bub_qq/auth.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from .config import QQConfig
+
+
+@dataclass(frozen=True)
+class QQAccessToken:
+    """Cached access token and its refresh boundary."""
+
+    value: str
+    expires_at: float
+
+    def is_valid(self, *, now: float) -> bool:
+        return now < self.expires_at
+
+
+class QQAuthError(RuntimeError):
+    """Raised when QQ token acquisition fails."""
+
+
+class QQTokenProvider:
+    """Fetch and cache QQ Open Platform access tokens."""
+
+    def __init__(
+        self,
+        config: QQConfig,
+        *,
+        client: httpx.AsyncClient | None = None,
+        clock: Any | None = None,
+    ) -> None:
+        self._config = config
+        self._client = client
+        self._clock = clock or time.time
+        self._token: QQAccessToken | None = None
+        self._lock = asyncio.Lock()
+
+    async def get_token(self) -> str:
+        now = float(self._clock())
+        token = self._token
+        if token is not None and token.is_valid(now=now):
+            return token.value
+
+        async with self._lock:
+            now = float(self._clock())
+            token = self._token
+            if token is not None and token.is_valid(now=now):
+                return token.value
+
+            self._token = await self._request_new_token()
+            return self._token.value
+
+    async def _request_new_token(self) -> QQAccessToken:
+        if not self._config.appid or not self._config.secret:
+            raise QQAuthError("qq appid/secret is empty")
+
+        response = await self._request_token()
+        payload = response.json()
+
+        access_token = str(payload.get("access_token") or "").strip()
+        expires_in = payload.get("expires_in")
+        if not access_token:
+            raise QQAuthError(f"qq token response missing access_token: {payload}")
+
+        try:
+            expires_in_seconds = int(expires_in)
+        except (TypeError, ValueError) as exc:
+            raise QQAuthError(f"qq token response has invalid expires_in: {payload}") from exc
+
+        refresh_after = max(expires_in_seconds - self._config.token_refresh_skew_seconds, 0)
+        return QQAccessToken(
+            value=access_token,
+            expires_at=float(self._clock()) + refresh_after,
+        )
+
+    async def _request_token(self) -> httpx.Response:
+        kwargs: dict[str, Any] = {
+            "json": {
+                "appId": self._config.appid,
+                "clientSecret": self._config.secret,
+            },
+            "headers": {"Content-Type": "application/json"},
+            "timeout": self._config.timeout_seconds,
+        }
+        if self._client is not None:
+            response = await self._client.post(self._config.token_url, **kwargs)
+        else:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(self._config.token_url, **kwargs)
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise QQAuthError(f"qq token request failed: {exc}") from exc
+        return response

--- a/packages/bub-qq/src/bub_qq/auth.py
+++ b/packages/bub-qq/src/bub_qq/auth.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass
-from typing import Any
+from collections.abc import Callable
+from typing import Protocol
 
-import httpx
+import aiohttp
 
 from .config import QQConfig
 
@@ -25,6 +26,10 @@ class QQAuthError(RuntimeError):
     """Raised when QQ token acquisition fails."""
 
 
+class TokenHTTPClient(Protocol):
+    async def post(self, url: str, **kwargs: object) -> dict[str, object]: ...
+
+
 class QQTokenProvider:
     """Fetch and cache QQ Open Platform access tokens."""
 
@@ -32,8 +37,8 @@ class QQTokenProvider:
         self,
         config: QQConfig,
         *,
-        client: httpx.AsyncClient | None = None,
-        clock: Any | None = None,
+        client: TokenHTTPClient | None = None,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         self._config = config
         self._client = client
@@ -60,8 +65,7 @@ class QQTokenProvider:
         if not self._config.appid or not self._config.secret:
             raise QQAuthError("qq appid/secret is empty")
 
-        response = await self._request_token()
-        payload = response.json()
+        payload = await self._request_token()
 
         access_token = str(payload.get("access_token") or "").strip()
         expires_in = payload.get("expires_in")
@@ -79,8 +83,8 @@ class QQTokenProvider:
             expires_at=float(self._clock()) + refresh_after,
         )
 
-    async def _request_token(self) -> httpx.Response:
-        kwargs: dict[str, Any] = {
+    async def _request_token(self) -> dict[str, object]:
+        kwargs: dict[str, object] = {
             "json": {
                 "appId": self._config.appid,
                 "clientSecret": self._config.secret,
@@ -89,13 +93,15 @@ class QQTokenProvider:
             "timeout": self._config.timeout_seconds,
         }
         if self._client is not None:
-            response = await self._client.post(self._config.token_url, **kwargs)
-        else:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(self._config.token_url, **kwargs)
+            return await self._client.post(self._config.token_url, **kwargs)
 
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as exc:
-            raise QQAuthError(f"qq token request failed: {exc}") from exc
-        return response
+        async with aiohttp.ClientSession() as client:
+            async with client.post(self._config.token_url, **kwargs) as response:
+                if response.status < 200 or response.status >= 300:
+                    raise QQAuthError(
+                        f"qq token request failed: http={response.status} reason={response.reason}"
+                    )
+                payload = await response.json()
+                if not isinstance(payload, dict):
+                    raise QQAuthError(f"qq token response is not a JSON object: {payload!r}")
+                return payload

--- a/packages/bub-qq/src/bub_qq/c2c.py
+++ b/packages/bub-qq/src/bub_qq/c2c.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from typing import Protocol
 from typing import Any
 
 from bub.channels.message import ChannelMessage
+from loguru import logger
 
 from .models import QQC2CMessage
+from .openapi_errors import QQOpenAPIError
+from .send_errors import is_duplicate_send_error
+from .send_errors import log_send_duplicate_error
+from .send_errors import log_send_error
 
 
 @dataclass
@@ -18,6 +26,15 @@ class QQC2CSessionState:
     latest_message_id_by_session: dict[str, str]
     latest_sequence_by_session: dict[str, int]
     latest_timestamp_by_session: dict[str, str]
+    send_record_by_session_and_msg_id: dict[tuple[str, str], "QQC2CSendRecord"]
+
+
+@dataclass
+class QQC2CSendRecord:
+    content: str
+    content_hash: str
+    msg_seq: int
+    result: dict[str, object]
 
 
 class QQC2CDeduper:
@@ -38,6 +55,174 @@ class QQC2CDeduper:
         if evicted is not None and evicted not in self._ids:
             self._id_set.discard(evicted)
         return False
+
+
+class QQC2COpenAPI(Protocol):
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, object]: ...
+
+
+class QQC2CInboundService:
+    def __init__(self, *, channel_name: str, deduper: QQC2CDeduper, state: QQC2CSessionState) -> None:
+        self._channel_name = channel_name
+        self._deduper = deduper
+        self._state = state
+
+    def parse_inbound(self, payload: dict[str, Any]) -> tuple[QQC2CMessage, ChannelMessage] | None:
+        try:
+            message = QQC2CMessage.from_event(payload)
+        except ValueError as exc:
+            logger.warning("qq.c2c.invalid_payload error={}", exc)
+            return None
+
+        if self._deduper.seen(message.message_id):
+            logger.info("qq.c2c.duplicate message_id={}", message.message_id)
+            return None
+
+        channel_message = build_c2c_channel_message(self._channel_name, message)
+        remember_c2c_session(
+            self._state,
+            session_id=channel_message.session_id,
+            message_id=message.message_id,
+            timestamp=message.timestamp,
+            sequence=message.sequence,
+        )
+        return message, channel_message
+
+
+class QQC2CSendService:
+    def __init__(
+        self,
+        *,
+        channel_name: str,
+        receive_mode: str,
+        state: QQC2CSessionState,
+        openapi: QQC2COpenAPI,
+    ) -> None:
+        self._channel_name = channel_name
+        self._receive_mode = receive_mode
+        self._state = state
+        self._openapi = openapi
+
+    async def send(self, message: ChannelMessage) -> dict[str, object] | None:
+        content = normalize_c2c_outbound_content(message.content or "")
+        if not content:
+            logger.warning("qq.send skip_empty session_id={}", message.session_id)
+            return None
+
+        session_id = message.session_id or ""
+        chat_id = message.chat_id or ""
+        openid = resolve_c2c_openid(
+            channel_name=self._channel_name,
+            session_id=session_id,
+            chat_id=chat_id,
+        )
+        if not openid:
+            logger.warning(
+                "qq.send unresolved_openid session_id={} chat_id={}",
+                message.session_id,
+                message.chat_id,
+            )
+            return None
+
+        msg_id = self._state.latest_message_id_by_session.get(session_id)
+        if not msg_id:
+            logger.warning(
+                "qq.send missing_msg_id session_id={} reason=active_push_not_supported",
+                session_id,
+            )
+            return None
+
+        if not is_passive_reply_window_open(self._state, session_id):
+            logger.warning(
+                "qq.send passive_reply_window_expired session_id={} msg_id={}",
+                session_id,
+                msg_id,
+            )
+            return None
+
+        content_hash = hash_c2c_content(content)
+        send_record = self._state.send_record_by_session_and_msg_id.get((session_id, msg_id))
+        if send_record is not None:
+            if send_record.content_hash == content_hash:
+                logger.info(
+                    "qq.send duplicate session_id={} openid={} msg_id={} reason=already_sent source=local_dedup_hit msg_seq={} content_hash={}",
+                    session_id,
+                    openid,
+                    msg_id,
+                    send_record.msg_seq,
+                    content_hash,
+                )
+                return build_already_sent_result(send_record)
+            logger.warning(
+                "qq.send duplicate session_id={} openid={} msg_id={} reason=duplicate_reply_blocked source=local_dedup_hit previous_msg_seq={} previous_content_hash={} content_hash={}",
+                session_id,
+                openid,
+                msg_id,
+                send_record.msg_seq,
+                send_record.content_hash,
+                content_hash,
+            )
+            return {"status": "duplicate_reply_blocked"}
+
+        msg_seq = next_c2c_msg_seq(self._state, session_id)
+        try:
+            result = await self._openapi.post_c2c_text_message(
+                openid=openid,
+                content=content,
+                msg_id=msg_id,
+                msg_seq=msg_seq,
+            )
+        except QQOpenAPIError as exc:
+            if is_duplicate_send_error(exc):
+                log_send_duplicate_error(
+                    exc,
+                    session_id=session_id,
+                    openid=openid,
+                    msg_id=msg_id,
+                    msg_seq=msg_seq,
+                    content_hash=content_hash,
+                )
+                duplicate_record = QQC2CSendRecord(
+                    content=content,
+                    content_hash=content_hash,
+                    msg_seq=msg_seq,
+                    result={},
+                )
+                self._state.send_record_by_session_and_msg_id[(session_id, msg_id)] = duplicate_record
+                return build_already_sent_result(duplicate_record)
+            log_send_error(
+                exc,
+                session_id=session_id,
+                openid=openid,
+                msg_id=msg_id,
+                msg_seq=msg_seq,
+                receive_mode=self._receive_mode,
+            )
+            return None
+
+        send_record = QQC2CSendRecord(
+            content=content,
+            content_hash=content_hash,
+            msg_seq=msg_seq,
+            result=dict(result),
+        )
+        self._state.send_record_by_session_and_msg_id[(session_id, msg_id)] = send_record
+        logger.info(
+            "qq.send success session_id={} openid={} msg_id={} msg_seq={} response_id={}",
+            session_id,
+            openid,
+            msg_id,
+            msg_seq,
+            result.get("id"),
+        )
+        return result
 
 
 def build_c2c_channel_message(channel_name: str, message: QQC2CMessage) -> ChannelMessage:
@@ -82,7 +267,6 @@ def build_c2c_channel_message(channel_name: str, message: QQC2CMessage) -> Chann
         channel=channel_name,
         chat_id=chat_id,
         is_active=True,
-        output_channel="null",
     )
 
 
@@ -97,8 +281,6 @@ def remember_c2c_session(
     state.latest_message_id_by_session[session_id] = message_id
     if timestamp is not None:
         state.latest_timestamp_by_session[session_id] = timestamp
-    if sequence is not None:
-        state.latest_sequence_by_session[session_id] = sequence
 
 
 def resolve_c2c_openid(*, channel_name: str, session_id: str, chat_id: str) -> str | None:
@@ -116,6 +298,22 @@ def next_c2c_msg_seq(state: QQC2CSessionState, session_id: str) -> int:
     current = state.latest_sequence_by_session.get(session_id, 0) + 1
     state.latest_sequence_by_session[session_id] = current
     return current
+
+
+def build_already_sent_result(send_record: QQC2CSendRecord) -> dict[str, object]:
+    result = dict(send_record.result)
+    result["status"] = "already_sent"
+    return result
+
+
+def hash_c2c_content(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+
+def normalize_c2c_outbound_content(content: str) -> str:
+    normalized = content.strip()
+    normalized = re.sub(r"^\$qq\s*→\s*", "", normalized, count=1, flags=re.IGNORECASE)
+    return normalized.strip()
 
 
 def is_passive_reply_window_open(state: QQC2CSessionState, session_id: str) -> bool:

--- a/packages/bub-qq/src/bub_qq/c2c.py
+++ b/packages/bub-qq/src/bub_qq/c2c.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+from bub.channels.message import ChannelMessage
+
+from .models import QQC2CMessage
+
+
+@dataclass
+class QQC2CSessionState:
+    latest_message_id_by_session: dict[str, str]
+    latest_sequence_by_session: dict[str, int]
+    latest_timestamp_by_session: dict[str, str]
+
+
+class QQC2CDeduper:
+    """Bounded recent-message cache for duplicate QQ deliveries."""
+
+    def __init__(self, size: int) -> None:
+        self._ids: deque[str] = deque(maxlen=size)
+        self._id_set: set[str] = set()
+
+    def seen(self, message_id: str) -> bool:
+        if message_id in self._id_set:
+            return True
+        evicted: str | None = None
+        if len(self._ids) == self._ids.maxlen:
+            evicted = self._ids[0]
+        self._ids.append(message_id)
+        self._id_set.add(message_id)
+        if evicted is not None and evicted not in self._ids:
+            self._id_set.discard(evicted)
+        return False
+
+
+def build_c2c_channel_message(channel_name: str, message: QQC2CMessage) -> ChannelMessage:
+    session_id = f"{channel_name}:c2c:{message.user_openid}"
+    chat_id = f"c2c:{message.user_openid}"
+    text = message.content.strip()
+
+    if text.startswith(","):
+        return ChannelMessage(
+            session_id=session_id,
+            content=text,
+            channel=channel_name,
+            chat_id=chat_id,
+            kind="command",
+            is_active=True,
+        )
+
+    payload = {
+        "message": message.content,
+        "message_id": message.message_id,
+        "type": "text" if not message.attachments else "attachment",
+        "sender_id": message.user_openid,
+        "date": message.timestamp,
+        "attachments": [
+            {
+                "content_type": attachment.content_type,
+                "filename": attachment.filename,
+                "height": attachment.height,
+                "width": attachment.width,
+                "size": attachment.size,
+                "url": attachment.url,
+                "voice_wav_url": attachment.voice_wav_url,
+                "asr_refer_text": attachment.asr_refer_text,
+            }
+            for attachment in message.attachments
+        ]
+        or None,
+    }
+    return ChannelMessage(
+        session_id=session_id,
+        content=json.dumps(exclude_none(payload), ensure_ascii=False),
+        channel=channel_name,
+        chat_id=chat_id,
+        is_active=True,
+        output_channel="null",
+    )
+
+
+def remember_c2c_session(
+    state: QQC2CSessionState,
+    *,
+    session_id: str,
+    message_id: str,
+    timestamp: str | None,
+    sequence: int | None,
+) -> None:
+    state.latest_message_id_by_session[session_id] = message_id
+    if timestamp is not None:
+        state.latest_timestamp_by_session[session_id] = timestamp
+    if sequence is not None:
+        state.latest_sequence_by_session[session_id] = sequence
+
+
+def resolve_c2c_openid(*, channel_name: str, session_id: str, chat_id: str) -> str | None:
+    if chat_id.startswith("c2c:"):
+        openid = chat_id.removeprefix("c2c:").strip()
+        return openid or None
+    prefix = f"{channel_name}:c2c:"
+    if session_id.startswith(prefix):
+        openid = session_id.removeprefix(prefix).strip()
+        return openid or None
+    return None
+
+
+def next_c2c_msg_seq(state: QQC2CSessionState, session_id: str) -> int:
+    current = state.latest_sequence_by_session.get(session_id, 0) + 1
+    state.latest_sequence_by_session[session_id] = current
+    return current
+
+
+def is_passive_reply_window_open(state: QQC2CSessionState, session_id: str) -> bool:
+    timestamp = state.latest_timestamp_by_session.get(session_id)
+    if not timestamp:
+        return True
+    try:
+        sent_at = datetime.fromisoformat(timestamp)
+    except ValueError:
+        return True
+    if sent_at.tzinfo is None:
+        sent_at = sent_at.replace(tzinfo=timezone.utc)
+    return datetime.now(sent_at.tzinfo) - sent_at <= timedelta(minutes=60)
+
+
+def exclude_none(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}

--- a/packages/bub-qq/src/bub_qq/channel.py
+++ b/packages/bub-qq/src/bub_qq/channel.py
@@ -1,0 +1,197 @@
+"""QQ channel with auth, OpenAPI and pluggable receive transports."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from bub.channels import Channel
+from bub.channels.message import ChannelMessage
+from bub.types import MessageHandler
+from loguru import logger
+
+from .auth import QQTokenProvider
+from .c2c import build_c2c_channel_message
+from .c2c import is_passive_reply_window_open
+from .c2c import next_c2c_msg_seq
+from .c2c import QQC2CDeduper
+from .c2c import QQC2CSessionState
+from .c2c import remember_c2c_session
+from .c2c import resolve_c2c_openid
+from .config import QQConfig
+from .models import QQC2CMessage
+from .openapi import QQOpenAPI
+from .openapi_errors import QQOpenAPIError
+from .send_errors import log_send_error
+from .webhook import QQWebhookServer
+from .websocket import QQWebSocketClient
+
+
+class QQChannel(Channel):
+    """QQ channel registration with reusable auth and OpenAPI client."""
+
+    name = "qq"
+
+    def __init__(self, on_receive: MessageHandler) -> None:
+        self._on_receive = on_receive
+        self._config = QQConfig()
+        self._token_provider = QQTokenProvider(self._config)
+        self._openapi = QQOpenAPI(self._config, self._token_provider)
+        self._webhook = QQWebhookServer(self._config, self._handle_transport_payload)
+        self._websocket = QQWebSocketClient(self._config, self._openapi, self._handle_transport_payload)
+        self._c2c_deduper = QQC2CDeduper(self._config.inbound_dedupe_size)
+        self._c2c_state = QQC2CSessionState(
+            latest_message_id_by_session={},
+            latest_sequence_by_session={},
+            latest_timestamp_by_session={},
+        )
+
+    @property
+    def needs_debounce(self) -> bool:
+        return True
+
+    async def start(self, stop_event: Any) -> None:
+        if not self._config.appid or not self._config.secret:
+            raise RuntimeError("qq appid/secret is empty")
+
+        mode = self._normalize_receive_mode()
+        if mode == "webhook":
+            await self._webhook.start()
+            logger.info(
+                "qq.start mode=webhook token_url={} openapi_base_url={} webhook=http://{}:{}{}",
+                self._config.token_url,
+                self._config.openapi_base_url,
+                self._config.webhook_host,
+                self._config.webhook_port,
+                self._config.webhook_path,
+            )
+            return
+
+        websocket_stop = stop_event if isinstance(stop_event, asyncio.Event) else None
+        await self._websocket.start(websocket_stop)
+        logger.info(
+            "qq.start mode=websocket token_url={} openapi_base_url={} intents={}",
+            self._config.token_url,
+            self._config.openapi_base_url,
+            self._config.websocket_intents,
+        )
+
+    async def stop(self) -> None:
+        await self._webhook.stop()
+        await self._websocket.stop()
+        await self._openapi.aclose()
+        logger.info("qq.stopped")
+
+    async def send(self, message: ChannelMessage) -> None:
+        content = (message.content or "").strip()
+        if not content:
+            logger.warning("qq.send skip_empty session_id={}", message.session_id)
+            return
+
+        session_id = message.session_id or ""
+        chat_id = message.chat_id or ""
+        openid = resolve_c2c_openid(channel_name=self.name, session_id=session_id, chat_id=chat_id)
+        if not openid:
+            logger.warning(
+                "qq.send unresolved_openid session_id={} chat_id={}",
+                message.session_id,
+                message.chat_id,
+            )
+            return
+
+        msg_id = self._c2c_state.latest_message_id_by_session.get(session_id)
+        if not msg_id:
+            logger.warning(
+                "qq.send missing_msg_id session_id={} reason=active_push_not_supported",
+                session_id,
+            )
+            return
+
+        if not is_passive_reply_window_open(self._c2c_state, session_id):
+            logger.warning(
+                "qq.send passive_reply_window_expired session_id={} msg_id={}",
+                session_id,
+                msg_id,
+            )
+            return
+
+        msg_seq = next_c2c_msg_seq(self._c2c_state, session_id)
+        try:
+            result = await self._openapi.post_c2c_text_message(
+                openid=openid,
+                content=content,
+                msg_id=msg_id,
+                msg_seq=msg_seq,
+            )
+        except QQOpenAPIError as exc:
+            log_send_error(
+                exc,
+                session_id=session_id,
+                openid=openid,
+                msg_id=msg_id,
+                msg_seq=msg_seq,
+                receive_mode=self._config.receive_mode,
+            )
+            return
+
+        logger.info(
+            "qq.send success session_id={} openid={} msg_id={} msg_seq={} response_id={}",
+            session_id,
+            openid,
+            msg_id,
+            msg_seq,
+            result.get("id"),
+        )
+
+    async def _handle_transport_payload(self, payload: dict[str, Any]) -> None:
+        op = payload.get("op")
+        event_type = payload.get("t")
+        if op != 0:
+            logger.info("qq.transport.ignored op={} t={}", op, event_type)
+            return
+        if event_type == "READY":
+            logger.info("qq.websocket.ready")
+            return
+        if event_type == "RESUMED":
+            logger.info("qq.websocket.resumed")
+            return
+        if event_type == "C2C_MESSAGE_CREATE":
+            await self._handle_c2c_message(payload)
+            return
+        logger.info("qq.transport.unhandled event={} op={}", event_type, op)
+
+    async def _handle_c2c_message(self, payload: dict[str, Any]) -> None:
+        try:
+            message = QQC2CMessage.from_event(payload)
+        except ValueError as exc:
+            logger.warning("qq.c2c.invalid_payload error={}", exc)
+            return
+
+        if self._c2c_deduper.seen(message.message_id):
+            logger.info("qq.c2c.duplicate message_id={}", message.message_id)
+            return
+
+        channel_message = build_c2c_channel_message(self.name, message)
+        remember_c2c_session(
+            self._c2c_state,
+            session_id=channel_message.session_id,
+            message_id=message.message_id,
+            timestamp=message.timestamp,
+            sequence=message.sequence,
+        )
+        logger.info(
+            "qq.c2c.inbound session_id={} user_openid={} content_len={} attachments={}",
+            channel_message.session_id,
+            message.user_openid,
+            len(message.content),
+            len(message.attachments),
+        )
+        await self._on_receive(channel_message)
+
+    def _normalize_receive_mode(self) -> str:
+        mode = (self._config.receive_mode or "").strip().lower()
+        if mode not in {"webhook", "websocket"}:
+            raise RuntimeError(
+                f"qq receive_mode must be webhook or websocket, got {self._config.receive_mode!r}"
+            )
+        return mode

--- a/packages/bub-qq/src/bub_qq/channel.py
+++ b/packages/bub-qq/src/bub_qq/channel.py
@@ -11,18 +11,12 @@ from bub.types import MessageHandler
 from loguru import logger
 
 from .auth import QQTokenProvider
-from .c2c import build_c2c_channel_message
-from .c2c import is_passive_reply_window_open
-from .c2c import next_c2c_msg_seq
 from .c2c import QQC2CDeduper
+from .c2c import QQC2CInboundService
+from .c2c import QQC2CSendService
 from .c2c import QQC2CSessionState
-from .c2c import remember_c2c_session
-from .c2c import resolve_c2c_openid
 from .config import QQConfig
-from .models import QQC2CMessage
 from .openapi import QQOpenAPI
-from .openapi_errors import QQOpenAPIError
-from .send_errors import log_send_error
 from .webhook import QQWebhookServer
 from .websocket import QQWebSocketClient
 
@@ -44,13 +38,25 @@ class QQChannel(Channel):
             latest_message_id_by_session={},
             latest_sequence_by_session={},
             latest_timestamp_by_session={},
+            send_record_by_session_and_msg_id={},
+        )
+        self._c2c_inbound = QQC2CInboundService(
+            channel_name=self.name,
+            deduper=self._c2c_deduper,
+            state=self._c2c_state,
+        )
+        self._c2c_send = QQC2CSendService(
+            channel_name=self.name,
+            receive_mode=self._config.receive_mode,
+            state=self._c2c_state,
+            openapi=self._openapi,
         )
 
     @property
     def needs_debounce(self) -> bool:
         return True
 
-    async def start(self, stop_event: Any) -> None:
+    async def start(self, stop_event: asyncio.Event | None) -> None:
         if not self._config.appid or not self._config.secret:
             raise RuntimeError("qq appid/secret is empty")
 
@@ -67,8 +73,7 @@ class QQChannel(Channel):
             )
             return
 
-        websocket_stop = stop_event if isinstance(stop_event, asyncio.Event) else None
-        await self._websocket.start(websocket_stop)
+        await self._websocket.start(stop_event)
         logger.info(
             "qq.start mode=websocket token_url={} openapi_base_url={} intents={}",
             self._config.token_url,
@@ -83,65 +88,7 @@ class QQChannel(Channel):
         logger.info("qq.stopped")
 
     async def send(self, message: ChannelMessage) -> None:
-        content = (message.content or "").strip()
-        if not content:
-            logger.warning("qq.send skip_empty session_id={}", message.session_id)
-            return
-
-        session_id = message.session_id or ""
-        chat_id = message.chat_id or ""
-        openid = resolve_c2c_openid(channel_name=self.name, session_id=session_id, chat_id=chat_id)
-        if not openid:
-            logger.warning(
-                "qq.send unresolved_openid session_id={} chat_id={}",
-                message.session_id,
-                message.chat_id,
-            )
-            return
-
-        msg_id = self._c2c_state.latest_message_id_by_session.get(session_id)
-        if not msg_id:
-            logger.warning(
-                "qq.send missing_msg_id session_id={} reason=active_push_not_supported",
-                session_id,
-            )
-            return
-
-        if not is_passive_reply_window_open(self._c2c_state, session_id):
-            logger.warning(
-                "qq.send passive_reply_window_expired session_id={} msg_id={}",
-                session_id,
-                msg_id,
-            )
-            return
-
-        msg_seq = next_c2c_msg_seq(self._c2c_state, session_id)
-        try:
-            result = await self._openapi.post_c2c_text_message(
-                openid=openid,
-                content=content,
-                msg_id=msg_id,
-                msg_seq=msg_seq,
-            )
-        except QQOpenAPIError as exc:
-            log_send_error(
-                exc,
-                session_id=session_id,
-                openid=openid,
-                msg_id=msg_id,
-                msg_seq=msg_seq,
-                receive_mode=self._config.receive_mode,
-            )
-            return
-
-        logger.info(
-            "qq.send success session_id={} openid={} msg_id={} msg_seq={} response_id={}",
-            session_id,
-            openid,
-            msg_id,
-            msg_seq,
-            result.get("id"),
-        )
+        await self._c2c_send.send(message)
 
     async def _handle_transport_payload(self, payload: dict[str, Any]) -> None:
         op = payload.get("op")
@@ -161,24 +108,10 @@ class QQChannel(Channel):
         logger.info("qq.transport.unhandled event={} op={}", event_type, op)
 
     async def _handle_c2c_message(self, payload: dict[str, Any]) -> None:
-        try:
-            message = QQC2CMessage.from_event(payload)
-        except ValueError as exc:
-            logger.warning("qq.c2c.invalid_payload error={}", exc)
+        parsed = self._c2c_inbound.parse_inbound(payload)
+        if parsed is None:
             return
-
-        if self._c2c_deduper.seen(message.message_id):
-            logger.info("qq.c2c.duplicate message_id={}", message.message_id)
-            return
-
-        channel_message = build_c2c_channel_message(self.name, message)
-        remember_c2c_session(
-            self._c2c_state,
-            session_id=channel_message.session_id,
-            message_id=message.message_id,
-            timestamp=message.timestamp,
-            sequence=message.sequence,
-        )
+        message, channel_message = parsed
         logger.info(
             "qq.c2c.inbound session_id={} user_openid={} content_len={} attachments={}",
             channel_message.session_id,

--- a/packages/bub-qq/src/bub_qq/channel.py
+++ b/packages/bub-qq/src/bub_qq/channel.py
@@ -64,7 +64,7 @@ class QQChannel(Channel):
         if mode == "webhook":
             await self._webhook.start()
             logger.info(
-                "qq.start mode=webhook token_url={} openapi_base_url={} webhook=http://{}:{}{}",
+                "qq.start mode=webhook token_url={} openapi_base_url={} webhook=http://{}:{}{} websocket=disabled",
                 self._config.token_url,
                 self._config.openapi_base_url,
                 self._config.webhook_host,
@@ -75,7 +75,7 @@ class QQChannel(Channel):
 
         await self._websocket.start(stop_event)
         logger.info(
-            "qq.start mode=websocket token_url={} openapi_base_url={} intents={}",
+            "qq.start mode=websocket token_url={} openapi_base_url={} intents={} webhook=disabled",
             self._config.token_url,
             self._config.openapi_base_url,
             self._config.websocket_intents,

--- a/packages/bub-qq/src/bub_qq/config.py
+++ b/packages/bub-qq/src/bub_qq/config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class QQConfig(BaseSettings):
+    """QQ Open Platform adapter config."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="BUB_QQ_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    appid: str = ""
+    secret: str = ""
+    token_url: str = "https://bots.qq.com/app/getAppAccessToken"
+    openapi_base_url: str = "https://api.sgroup.qq.com"
+    timeout_seconds: float = 30.0
+    token_refresh_skew_seconds: int = 60
+    receive_mode: str = "webhook"
+    webhook_host: str = "127.0.0.1"
+    webhook_port: int = 9009
+    webhook_path: str = "/qq/webhook"
+    webhook_callback_timeout_seconds: float = 15.0
+    verify_signature: bool = True
+    inbound_dedupe_size: int = 1024
+    websocket_intents: int = 1 << 25
+    websocket_use_shard_gateway: bool = False
+    websocket_reconnect_delay_seconds: float = 5.0

--- a/packages/bub-qq/src/bub_qq/config.py
+++ b/packages/bub-qq/src/bub_qq/config.py
@@ -19,9 +19,12 @@ class QQConfig(BaseSettings):
     openapi_base_url: str = "https://api.sgroup.qq.com"
     timeout_seconds: float = 30.0
     token_refresh_skew_seconds: int = 60
-    receive_mode: str = "webhook"
+    receive_mode: str = Field(
+        ...,
+        description="QQ inbound transport mode. Must be set to 'webhook' or 'websocket'.",
+    )
     webhook_host: str = "127.0.0.1"
-    webhook_port: int = 9009
+    webhook_port: int = 8080
     webhook_path: str = "/qq/webhook"
     webhook_callback_timeout_seconds: float = 15.0
     verify_signature: bool = True

--- a/packages/bub-qq/src/bub_qq/config.py
+++ b/packages/bub-qq/src/bub_qq/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -24,7 +25,7 @@ class QQConfig(BaseSettings):
     webhook_path: str = "/qq/webhook"
     webhook_callback_timeout_seconds: float = 15.0
     verify_signature: bool = True
-    inbound_dedupe_size: int = 1024
+    inbound_dedupe_size: int = Field(default=1024, ge=1)
     websocket_intents: int = 1 << 25
     websocket_use_shard_gateway: bool = False
     websocket_reconnect_delay_seconds: float = 5.0

--- a/packages/bub-qq/src/bub_qq/gateway.py
+++ b/packages/bub-qq/src/bub_qq/gateway.py
@@ -7,10 +7,24 @@ from .openapi import QQOpenAPI
 
 
 @dataclass(frozen=True)
+class QQSessionStartLimit:
+    total: int
+    remaining: int
+    reset_after: int
+    max_concurrency: int
+
+
+@dataclass(frozen=True)
 class QQGatewayInfo:
     url: str
     shards: int | None = None
-    max_concurrency: int | None = None
+    session_start_limit: QQSessionStartLimit | None = None
+
+    @property
+    def max_concurrency(self) -> int | None:
+        if self.session_start_limit is None:
+            return None
+        return self.session_start_limit.max_concurrency
 
 
 async def get_gateway(openapi: QQOpenAPI) -> QQGatewayInfo:
@@ -20,16 +34,10 @@ async def get_gateway(openapi: QQOpenAPI) -> QQGatewayInfo:
 
 async def get_shard_gateway(openapi: QQOpenAPI) -> QQGatewayInfo:
     payload = await openapi.get("/gateway/bot")
-    limit = payload.get("session_start_limit")
-    max_concurrency = None
-    if isinstance(limit, dict):
-        value = limit.get("max_concurrency")
-        if value is not None:
-            max_concurrency = int(value)
     return QQGatewayInfo(
         url=str(payload["url"]),
         shards=int(payload["shards"]) if payload.get("shards") is not None else None,
-        max_concurrency=max_concurrency,
+        session_start_limit=_parse_session_start_limit(payload.get("session_start_limit")),
     )
 
 
@@ -61,3 +69,17 @@ def resume_payload(*, token: str, session_id: str, sequence: int) -> dict[str, A
 
 def heartbeat_payload(sequence: int | None) -> dict[str, Any]:
     return {"op": 1, "d": sequence}
+
+
+def _parse_session_start_limit(payload: Any) -> QQSessionStartLimit | None:
+    if not isinstance(payload, dict):
+        return None
+    required_fields = ("total", "remaining", "reset_after", "max_concurrency")
+    if any(payload.get(field) is None for field in required_fields):
+        return None
+    return QQSessionStartLimit(
+        total=int(payload["total"]),
+        remaining=int(payload["remaining"]),
+        reset_after=int(payload["reset_after"]),
+        max_concurrency=int(payload["max_concurrency"]),
+    )

--- a/packages/bub-qq/src/bub_qq/gateway.py
+++ b/packages/bub-qq/src/bub_qq/gateway.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .openapi import QQOpenAPI
+
+
+@dataclass(frozen=True)
+class QQGatewayInfo:
+    url: str
+    shards: int | None = None
+    max_concurrency: int | None = None
+
+
+async def get_gateway(openapi: QQOpenAPI) -> QQGatewayInfo:
+    payload = await openapi.get("/gateway")
+    return QQGatewayInfo(url=str(payload["url"]))
+
+
+async def get_shard_gateway(openapi: QQOpenAPI) -> QQGatewayInfo:
+    payload = await openapi.get("/gateway/bot")
+    limit = payload.get("session_start_limit")
+    max_concurrency = None
+    if isinstance(limit, dict):
+        value = limit.get("max_concurrency")
+        if value is not None:
+            max_concurrency = int(value)
+    return QQGatewayInfo(
+        url=str(payload["url"]),
+        shards=int(payload["shards"]) if payload.get("shards") is not None else None,
+        max_concurrency=max_concurrency,
+    )
+
+
+def identify_payload(*, token: str, intents: int, shard: tuple[int, int] | None = None) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "token": f"QQBot {token}",
+        "intents": intents,
+        "properties": {
+            "$os": "macos",
+            "$browser": "bub-qq",
+            "$device": "bub-qq",
+        },
+    }
+    if shard is not None:
+        data["shard"] = [shard[0], shard[1]]
+    return {"op": 2, "d": data}
+
+
+def resume_payload(*, token: str, session_id: str, sequence: int) -> dict[str, Any]:
+    return {
+        "op": 6,
+        "d": {
+            "token": f"QQBot {token}",
+            "session_id": session_id,
+            "seq": sequence,
+        },
+    }
+
+
+def heartbeat_payload(sequence: int | None) -> dict[str, Any]:
+    return {"op": 1, "d": sequence}

--- a/packages/bub-qq/src/bub_qq/models.py
+++ b/packages/bub-qq/src/bub_qq/models.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class QQAttachment:
+    """Attachment info in QQ C2C events."""
+
+    content_type: str | None
+    filename: str | None
+    height: int | None
+    width: int | None
+    size: int | None
+    url: str | None
+    voice_wav_url: str | None
+    asr_refer_text: str | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> QQAttachment:
+        return cls(
+            content_type=_optional_str(payload.get("content_type")),
+            filename=_optional_str(payload.get("filename")),
+            height=_optional_int(payload.get("height")),
+            width=_optional_int(payload.get("width")),
+            size=_optional_int(payload.get("size")),
+            url=_optional_str(payload.get("url")),
+            voice_wav_url=_optional_str(payload.get("voice_wav_url")),
+            asr_refer_text=_optional_str(payload.get("asr_refer_text")),
+        )
+
+
+@dataclass(frozen=True)
+class QQC2CMessage:
+    """Normalized QQ C2C message event payload."""
+
+    message_id: str
+    user_openid: str
+    content: str
+    timestamp: str | None
+    attachments: tuple[QQAttachment, ...]
+    event_id: str | None
+    sequence: int | None
+
+    @classmethod
+    def from_event(cls, payload: dict[str, Any]) -> QQC2CMessage:
+        data = payload.get("d")
+        if not isinstance(data, dict):
+            raise ValueError("qq event payload.d must be an object")
+
+        author = data.get("author")
+        if not isinstance(author, dict):
+            raise ValueError("qq c2c event author must be an object")
+
+        message_id = _required_str(data.get("id"), "id")
+        user_openid = _required_str(author.get("user_openid"), "author.user_openid")
+        attachments_raw = data.get("attachments") or []
+        if not isinstance(attachments_raw, list):
+            raise ValueError("qq c2c event attachments must be an array")
+
+        return cls(
+            message_id=message_id,
+            user_openid=user_openid,
+            content=str(data.get("content") or ""),
+            timestamp=_optional_str(data.get("timestamp")),
+            attachments=tuple(
+                QQAttachment.from_payload(item)
+                for item in attachments_raw
+                if isinstance(item, dict)
+            ),
+            event_id=_optional_str(payload.get("id")),
+            sequence=_optional_int(payload.get("s")),
+        )
+
+
+def _required_str(value: Any, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"qq event field {field_name} is required")
+    return text
+
+
+def _optional_str(value: Any) -> str | None:
+    text = str(value).strip() if value is not None else ""
+    return text or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/packages/bub-qq/src/bub_qq/openapi.py
+++ b/packages/bub-qq/src/bub_qq/openapi.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .auth import QQTokenProvider
+from .config import QQConfig
+from .openapi_errors import build_openapi_error
+from .openapi_errors import QQOpenAPIError
+from .openapi_errors import trace_id_from_response
+
+
+class QQOpenAPI:
+    """Minimal QQ OpenAPI client using QQBot access_token auth."""
+
+    def __init__(
+        self,
+        config: QQConfig,
+        token_provider: QQTokenProvider,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._token_provider = token_provider
+        self._client = client or httpx.AsyncClient(
+            base_url=self._config.openapi_base_url,
+            timeout=self._config.timeout_seconds,
+        )
+        self._owns_client = client is None
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def get_access_token(self) -> str:
+        return await self._token_provider.get_token()
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        request_headers = {
+            "Authorization": f"QQBot {await self.get_access_token()}",
+            "Content-Type": "application/json",
+        }
+        if headers:
+            request_headers.update(headers)
+
+        response = await self._client.request(
+            method=method,
+            url=path,
+            params=params,
+            json=json_body,
+            headers=request_headers,
+        )
+        payload = _maybe_json(response)
+        if response.status_code < 200 or response.status_code >= 300:
+            raise build_openapi_error(response, payload)
+        if response.status_code in {201, 202}:
+            raise build_openapi_error(
+                response,
+                payload,
+                default_message="qq openapi async success requires follow-up handling",
+            )
+        if response.status_code == 204:
+            return {}
+        if not isinstance(payload, dict):
+            raise QQOpenAPIError(
+                status_code=response.status_code,
+                trace_id=trace_id_from_response(response),
+                error_code=None,
+                error_message=f"qq openapi response is not a JSON object: {payload!r}",
+                response_body=payload,
+            )
+        return payload
+
+    async def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        return await self.request("GET", path, params=params)
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await self.request("POST", path, json_body=json_body)
+
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, Any]:
+        return await self.post(
+            f"/v2/users/{openid}/messages",
+            json_body={
+                "content": content,
+                "msg_type": 0,
+                "msg_id": msg_id,
+                "msg_seq": msg_seq,
+            },
+        )
+
+
+def _maybe_json(response: httpx.Response) -> Any:
+    if not response.content:
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        return response.text

--- a/packages/bub-qq/src/bub_qq/openapi.py
+++ b/packages/bub-qq/src/bub_qq/openapi.py
@@ -1,14 +1,35 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
+from typing import Protocol
 
-import httpx
+import aiohttp
 
 from .auth import QQTokenProvider
 from .config import QQConfig
 from .openapi_errors import build_openapi_error
 from .openapi_errors import QQOpenAPIError
 from .openapi_errors import trace_id_from_response
+
+
+class ResponseLike(Protocol):
+    status: int
+    reason: str
+    headers: Mapping[str, str]
+    payload: Any
+
+
+class OpenAPIHTTPClient(Protocol):
+    async def request(
+        self,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, Any] | None,
+        json: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> ResponseLike: ...
 
 
 class QQOpenAPI:
@@ -19,19 +40,26 @@ class QQOpenAPI:
         config: QQConfig,
         token_provider: QQTokenProvider,
         *,
-        client: httpx.AsyncClient | None = None,
+        client: OpenAPIHTTPClient | None = None,
     ) -> None:
         self._config = config
         self._token_provider = token_provider
-        self._client = client or httpx.AsyncClient(
-            base_url=self._config.openapi_base_url,
-            timeout=self._config.timeout_seconds,
-        )
-        self._owns_client = client is None
+        self._client = client
+        self._session: aiohttp.ClientSession | None = None
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=self._config.timeout_seconds)
+            self._session = aiohttp.ClientSession(
+                base_url=self._config.openapi_base_url,
+                timeout=timeout,
+            )
+        return self._session
 
     async def aclose(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
 
     async def get_access_token(self) -> str:
         return await self._token_provider.get_token()
@@ -52,33 +80,66 @@ class QQOpenAPI:
         if headers:
             request_headers.update(headers)
 
-        response = await self._client.request(
+        response = await self._request(
             method=method,
-            url=path,
+            path=path,
             params=params,
-            json=json_body,
+            json_body=json_body,
             headers=request_headers,
         )
-        payload = _maybe_json(response)
-        if response.status_code < 200 or response.status_code >= 300:
+        payload = response.payload
+        if response.status < 200 or response.status >= 300:
             raise build_openapi_error(response, payload)
-        if response.status_code in {201, 202}:
+        if response.status in {201, 202}:
             raise build_openapi_error(
                 response,
                 payload,
                 default_message="qq openapi async success requires follow-up handling",
             )
-        if response.status_code == 204:
+        if response.status == 204:
             return {}
         if not isinstance(payload, dict):
             raise QQOpenAPIError(
-                status_code=response.status_code,
+                status_code=response.status,
                 trace_id=trace_id_from_response(response),
                 error_code=None,
                 error_message=f"qq openapi response is not a JSON object: {payload!r}",
                 response_body=payload,
             )
         return payload
+
+    async def _request(
+        self,
+        *,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None,
+        json_body: dict[str, Any] | None,
+        headers: dict[str, str],
+    ) -> ResponseLike:
+        if self._client is not None:
+            return await self._client.request(
+                method=method,
+                url=path,
+                params=params,
+                json=json_body,
+                headers=headers,
+            )
+
+        session = await self._get_session()
+        async with session.request(
+            method=method,
+            url=path,
+            params=params,
+            json=json_body,
+            headers=headers,
+        ) as response:
+            return _QQResponse(
+                status=response.status,
+                reason=response.reason or "",
+                headers=dict(response.headers),
+                payload=await _maybe_json(response),
+            )
 
     async def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
         return await self.request("GET", path, params=params)
@@ -110,10 +171,26 @@ class QQOpenAPI:
         )
 
 
-def _maybe_json(response: httpx.Response) -> Any:
-    if not response.content:
+class _QQResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        reason: str,
+        headers: dict[str, str],
+        payload: Any,
+    ) -> None:
+        self.status = status
+        self.reason = reason
+        self.headers = headers
+        self.payload = payload
+
+
+async def _maybe_json(response: aiohttp.ClientResponse) -> Any:
+    body = await response.read()
+    if not body:
         return None
     try:
-        return response.json()
-    except ValueError:
-        return response.text
+        return await response.json()
+    except (aiohttp.ContentTypeError, ValueError):
+        return body.decode(response.get_encoding() or "utf-8", errors="replace")

--- a/packages/bub-qq/src/bub_qq/openapi_errors.py
+++ b/packages/bub-qq/src/bub_qq/openapi_errors.py
@@ -129,6 +129,7 @@ KNOWN_OPENAPI_ERRORS: dict[int, QQKnownOpenAPIError] = {
     50055: _e(50055, "InvalidMarkdownContent", "无效的 markdown content", "request", False),
     50056: _e(50056, "MarkdownContentForbidden", "不允许发送 markdown content", "permission", False),
     50057: _e(50057, "MarkdownModeConflict", "markdown 参数只支持原生语法或者模版二选一", "request", False),
+    40054005: _e(40054005, "MessageDeduplicated", "消息被去重，请检查请求 msgseq", "reply", False),
     301000: _e(301000, "ChannelPermissionParamInvalid", "参数错误", "channel_permission", False),
     301001: _e(301001, "ChannelPermissionQueryGuildError", "查询频道信息错误", "channel_permission", True),
     301002: _e(301002, "ChannelPermissionQueryError", "查询子频道权限错误", "channel_permission", True),

--- a/packages/bub-qq/src/bub_qq/openapi_errors.py
+++ b/packages/bub-qq/src/bub_qq/openapi_errors.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+def _e(
+    code: int,
+    name: str,
+    description: str,
+    category: str,
+    retryable: bool,
+) -> "QQKnownOpenAPIError":
+    return QQKnownOpenAPIError(
+        code=code,
+        name=name,
+        description=description,
+        category=category,
+        retryable=retryable,
+    )
+
+
+@dataclass(frozen=True)
+class QQKnownOpenAPIError:
+    code: int
+    name: str
+    description: str
+    category: str
+    retryable: bool
+
+
+@dataclass
+class QQOpenAPIError(RuntimeError):
+    """QQ OpenAPI failure with transport, trace, and known-code context."""
+
+    status_code: int
+    trace_id: str | None
+    error_code: int | None
+    error_message: str
+    response_body: Any | None = None
+    known: QQKnownOpenAPIError | None = None
+
+    def __str__(self) -> str:
+        parts = [f"http={self.status_code}"]
+        if self.error_code is not None:
+            parts.append(f"code={self.error_code}")
+        if self.trace_id:
+            parts.append(f"trace_id={self.trace_id}")
+        if self.known is not None:
+            parts.append(f"category={self.known.category}")
+            parts.append(f"retryable={str(self.known.retryable).lower()}")
+            parts.append(self.known.name)
+        parts.append(self.error_message)
+        return "qq openapi error: " + " ".join(parts)
+
+
+HTTP_STATUS_DESCRIPTIONS: dict[int, str] = {
+    200: "成功",
+    201: "异步操作成功，但会返回错误体，需要特殊处理",
+    202: "异步操作成功，但会返回错误体，需要特殊处理",
+    204: "成功，无包体",
+    401: "认证失败",
+    404: "未找到 API",
+    405: "HTTP method 不允许",
+    429: "频率限制",
+    500: "处理失败",
+    504: "处理失败",
+}
+
+
+KNOWN_OPENAPI_ERRORS: dict[int, QQKnownOpenAPIError] = {
+    10001: _e(10001, "UnknownAccount", "账号异常", "auth", False),
+    10003: _e(10003, "UnknownChannel", "子频道异常", "resource", False),
+    10004: _e(10004, "UnknownGuild", "频道异常", "resource", False),
+    11241: _e(11241, "ErrorWrongToken", "参数中缺少 token", "auth", False),
+    11242: _e(11242, "ErrorCheckTokenFailed", "校验 token 失败", "auth", True),
+    11243: _e(11243, "ErrorCheckTokenNotPass", "用户填充的 token 错误", "auth", False),
+    11251: _e(11251, "ErrorWrongAppid", "appid 错误", "auth", False),
+    11252: _e(11252, "ErrorCheckAppPrivilegeFailed", "检查应用权限失败", "permission", True),
+    11253: _e(11253, "ErrorCheckAppPrivilegeNotPass", "应用未获得调用接口权限", "permission", False),
+    11254: _e(11254, "ErrorInterfaceForbidden", "接口被封禁", "permission", False),
+    11261: _e(11261, "ErrorWrongAppid", "参数中缺少 appid", "auth", False),
+    11262: _e(11262, "ErrorCheckRobot", "当前接口不支持使用机器人 Bot Token 调用", "auth", False),
+    11263: _e(11263, "ErrorCheckGuildAuth", "检查频道权限失败", "permission", True),
+    11264: _e(11264, "ErrorGuildAuthNotPass", "频道权限未通过", "permission", False),
+    11265: _e(11265, "ErrorRobotHasBaned", "机器人已经被封禁", "auth", False),
+    11273: _e(11273, "ErrorCheckUserAuth", "当前接口不支持使用 Bearer Token 调用", "auth", False),
+    11274: _e(11274, "ErrorUserAuthNotPass", "用户 OAuth 授权权限未通过", "permission", False),
+    11275: _e(11275, "ErrorWrongAppid", "无 appid", "auth", False),
+    11281: _e(11281, "ErrorCheckAdminFailed", "检查是否是管理员失败", "permission", True),
+    11282: _e(11282, "ErrorCheckAdminNotPass", "管理员权限未通过", "permission", False),
+    11301: _e(11301, "ErrorGetHTTPHeader", "HTTP Header 无效", "request", False),
+    11302: _e(11302, "ErrorGetHeaderUIN", "HTTP Header 无效", "request", False),
+    11303: _e(11303, "ErrorGetNick", "获取昵称失败", "platform", True),
+    11304: _e(11304, "ErrorGetAvatar", "获取头像失败", "platform", True),
+    11305: _e(11305, "ErrorGetGuildID", "获取频道 ID 失败", "platform", True),
+    11306: _e(11306, "ErrorGetGuildInfo", "获取频道信息失败", "platform", True),
+    12001: _e(12001, "ReplaceIDFailed", "替换 id 失败", "request", False),
+    12002: _e(12002, "RequestInvalid", "请求体错误", "request", False),
+    12003: _e(12003, "ResponseInvalid", "回包错误", "platform", True),
+    20028: _e(20028, "ChannelHitWriteRateLimit", "子频道消息触发限频", "rate_limit", True),
+    22009: _e(22009, "MsgLimitExceed", "消息发送超频", "rate_limit", True),
+    50006: _e(50006, "CannotSendEmptyMessage", "消息为空", "request", False),
+    50035: _e(50035, "InvalidFormBody", "form-data 内容异常", "request", False),
+    50037: _e(50037, "MarkdownKeyboardOnly", "带有 markdown 消息只支持 markdown 或 keyboard 组合", "request", False),
+    50038: _e(50038, "CrossChannelReference", "非同频道同子频道", "request", False),
+    50039: _e(50039, "GetMessageFailed", "获取消息失败", "platform", True),
+    50040: _e(50040, "MarkdownTemplateTypeError", "消息模版类型错误", "request", False),
+    50041: _e(50041, "MarkdownEmptyValue", "markdown 有空值", "request", False),
+    50042: _e(50042, "MarkdownListTooLong", "markdown 列表超限", "request", False),
+    50043: _e(50043, "GuildIdConvertFailed", "guild_id 转换失败", "request", False),
+    50045: _e(50045, "CannotReplySelf", "不能回复机器人自己产生的消息", "reply", False),
+    50046: _e(50046, "NotAtBotMessage", "非 at 机器人消息", "reply", False),
+    50047: _e(50047, "NotBotOrAtBotMessage", "非机器人产生的消息或者 at 机器人消息", "reply", False),
+    50048: _e(50048, "MessageIdRequired", "message id 不能为空", "reply", False),
+    50049: _e(50049, "KeyboardOnlyEditable", "只能修改含有 keyboard 元素的消息", "edit_message", False),
+    50050: _e(50050, "KeyboardRequiredWhenEditing", "修改消息时 keyboard 元素不能为空", "edit_message", False),
+    50051: _e(50051, "OnlyOwnMessageEditable", "只能修改机器人自己发送的消息", "edit_message", False),
+    50053: _e(50053, "EditMessageFailed", "修改消息错误", "edit_message", True),
+    50054: _e(50054, "MarkdownTemplateParamError", "markdown 模版参数错误", "request", False),
+    50055: _e(50055, "InvalidMarkdownContent", "无效的 markdown content", "request", False),
+    50056: _e(50056, "MarkdownContentForbidden", "不允许发送 markdown content", "permission", False),
+    50057: _e(50057, "MarkdownModeConflict", "markdown 参数只支持原生语法或者模版二选一", "request", False),
+    301000: _e(301000, "ChannelPermissionParamInvalid", "参数错误", "channel_permission", False),
+    301001: _e(301001, "ChannelPermissionQueryGuildError", "查询频道信息错误", "channel_permission", True),
+    301002: _e(301002, "ChannelPermissionQueryError", "查询子频道权限错误", "channel_permission", True),
+    301003: _e(301003, "ChannelPermissionUpdateError", "修改子频道权限错误", "channel_permission", True),
+    301004: _e(301004, "PrivateChannelMemberLimit", "私密子频道关联人数到达上限", "channel_permission", False),
+    301005: _e(301005, "ChannelPermissionRPCFailed", "调用 Rpc 服务失败", "channel_permission", True),
+    301006: _e(301006, "NonMemberNoPermission", "非群成员没有查询权限", "channel_permission", False),
+    301007: _e(301007, "ParamOverLimit", "参数超过数量限制", "channel_permission", False),
+    302000: _e(302000, "ScheduleParamInvalid", "参数错误", "schedule", False),
+    302001: _e(302001, "ScheduleQueryGuildError", "查询频道信息错误", "schedule", True),
+    302002: _e(302002, "ScheduleListFailed", "查询日程列表失败", "schedule", True),
+    302003: _e(302003, "ScheduleGetFailed", "查询日程失败", "schedule", True),
+    302004: _e(302004, "SchedulePatchFailed", "修改日程失败", "schedule", True),
+    302005: _e(302005, "ScheduleDeleteFailed", "删除日程失败", "schedule", True),
+    302006: _e(302006, "ScheduleCreateFailed", "创建日程失败", "schedule", True),
+    302007: _e(302007, "ScheduleCreatorInfoFailed", "获取创建者信息失败", "schedule", True),
+    302008: _e(302008, "ChannelIdRequired", "子频道 ID 不能为空", "schedule", False),
+    302009: _e(302009, "ScheduleSystemError", "频道系统错误", "schedule", True),
+    302010: _e(302010, "SchedulePermissionDenied", "暂无修改日程权限", "schedule", False),
+    302011: _e(302011, "ScheduleDeleted", "日程活动已被删除", "schedule", False),
+    302012: _e(302012, "ScheduleDailyLimit", "每天只能创建 10 个日程", "schedule", False),
+    302013: _e(302013, "ScheduleSafetyBlocked", "创建日程触发安全打击", "schedule", False),
+    302014: _e(302014, "ScheduleTooLong", "日程持续时间超过 7 天", "schedule", False),
+    302015: _e(302015, "ScheduleStartTooEarly", "开始时间不能早于当前时间", "schedule", False),
+    302016: _e(302016, "ScheduleEndTooEarly", "结束时间不能早于开始时间", "schedule", False),
+    302017: _e(302017, "ScheduleObjectEmpty", "Schedule 对象为空", "schedule", False),
+    302018: _e(302018, "ScheduleTypeConvertFailed", "参数类型转换失败", "schedule", False),
+    302019: _e(302019, "ScheduleDownstreamFailed", "调用下游失败", "schedule", True),
+    302020: _e(302020, "ScheduleContentViolation", "日程内容违规、账号违规", "schedule", False),
+    302021: _e(302021, "ScheduleDailyGuildLimit", "频道内当日新增活动达上限", "schedule", False),
+    302022: _e(302022, "ScheduleBindWrongChannel", "不能绑定非当前频道的子频道", "schedule", False),
+    302023: _e(302023, "ScheduleBindForbiddenOnJump", "开始时跳转不可绑定日程子频道", "schedule", False),
+    302024: _e(302024, "ScheduleBoundChannelMissing", "绑定的子频道不存在", "schedule", False),
+    304003: _e(304003, "URL_NOT_ALLOWED", "URL 未报备", "content", False),
+    304004: _e(304004, "ARK_NOT_ALLOWED", "没有发 ark 消息权限", "permission", False),
+    304005: _e(304005, "EMBED_LIMIT", "embed 长度超限", "request", False),
+    304006: _e(304006, "SERVER_CONFIG", "后台配置错误", "platform", True),
+    304007: _e(304007, "GET_GUILD", "查询频道异常", "resource", True),
+    304008: _e(304008, "GET_BOT", "查询机器人异常", "resource", True),
+    304009: _e(304009, "GET_CHENNAL", "查询子频道异常", "resource", True),
+    304010: _e(304010, "CHANGE_IMAGE_URL", "图片转存错误", "media", True),
+    304011: _e(304011, "NO_TEMPLATE", "模板不存在", "resource", False),
+    304012: _e(304012, "GET_TEMPLATE", "取模板错误", "platform", True),
+    304014: _e(304014, "TEMPLATE_PRIVILEGE", "没有模板权限", "permission", False),
+    304016: _e(304016, "SEND_ERROR", "发消息错误", "send", True),
+    304017: _e(304017, "UPLOAD_IMAGE", "图片上传错误", "media", True),
+    304018: _e(304018, "SESSION_NOT_EXIST", "机器人没连上 gateway", "gateway", True),
+    304019: _e(304019, "AT_EVERYONE_TIMES", "@全体成员次数超限", "rate_limit", False),
+    304020: _e(304020, "FILE_SIZE", "文件大小超限", "media", False),
+    304021: _e(304021, "GET_FILE", "下载文件错误", "media", True),
+    304022: _e(304022, "PUSH_TIME", "推送消息时间限制", "send", False),
+    304023: _e(304023, "PUSH_MSG_ASYNC_OK", "推送消息异步调用成功，等待人工审核", "async", False),
+    304024: _e(304024, "REPLY_MSG_ASYNC_OK", "回复消息异步调用成功，等待人工审核", "async", False),
+    304025: _e(304025, "BEAT", "消息被打击", "safety", False),
+    304026: _e(304026, "MSG_ID", "回复的消息 id 错误", "reply", False),
+    304027: _e(304027, "MSG_EXPIRE", "回复的消息过期", "reply", False),
+    304028: _e(304028, "MSG_PROTECT", "非 At 当前用户的消息不允许回复", "reply", False),
+    304029: _e(304029, "CORPUS_ERROR", "调语料服务错误", "platform", True),
+    304030: _e(304030, "CORPUS_NOT_MATCH", "语料不匹配", "content", False),
+    304031: _e(304031, "DM_CLOSED", "私信已关闭", "send", False),
+    304032: _e(304032, "DM_NOT_EXIST", "私信不存在", "resource", False),
+    304033: _e(304033, "DM_CREATE_ERROR", "拉私信错误", "send", True),
+    304034: _e(304034, "NOT_DM_MEMBER", "不是私信成员", "permission", False),
+    304035: _e(304035, "PUSH_CHANNEL_LIMIT", "推送消息超过子频道数量限制", "rate_limit", False),
+    304036: _e(304036, "NO_MARKDOWN_TEMPLATE_PERMISSION", "没有 markdown 模板权限", "permission", False),
+    304037: _e(304037, "NO_KEYBOARD_PERMISSION", "没有发消息按钮组件的权限", "permission", False),
+    304038: _e(304038, "KEYBOARD_NOT_EXIST", "消息按钮组件不存在", "resource", False),
+    304039: _e(304039, "KEYBOARD_PARSE_ERROR", "消息按钮组件解析错误", "request", False),
+    304040: _e(304040, "KEYBOARD_CONTENT_ERROR", "消息按钮组件消息内容错误", "request", False),
+    304044: _e(304044, "GET_MESSAGE_SETTING_ERROR", "取消息设置错误", "platform", True),
+    304045: _e(304045, "CHANNEL_PUSH_LIMIT", "子频道主动消息数限频", "rate_limit", False),
+    304046: _e(304046, "CHANNEL_PUSH_FORBIDDEN", "不允许在此子频道发主动消息", "permission", False),
+    304047: _e(304047, "GUILD_PUSH_CHANNEL_LIMIT", "主动消息推送超过限制的子频道数", "rate_limit", False),
+    304048: _e(304048, "GUILD_PUSH_FORBIDDEN", "不允许在此频道发主动消息", "permission", False),
+    304049: _e(304049, "DM_PUSH_LIMIT", "私信主动消息数限频", "rate_limit", False),
+    304050: _e(304050, "DM_PUSH_TOTAL_LIMIT", "私信主动消息总量限频", "rate_limit", False),
+    304051: _e(304051, "GUIDE_REQUEST_BUILD_ERROR", "消息设置引导请求构造错误", "request", False),
+    304052: _e(304052, "GUIDE_RATE_LIMIT", "发消息设置引导超频", "rate_limit", True),
+    306001: _e(306001, "DeleteMessageParamInvalid", "撤回消息参数错误", "delete_message", False),
+    306002: _e(306002, "DeleteMessageIdError", "消息 id 错误", "delete_message", False),
+    306003: _e(306003, "DeleteGetMessageFailed", "获取消息错误", "delete_message", True),
+    306004: _e(306004, "DeletePermissionDenied", "没有撤回此消息的权限", "delete_message", False),
+    306005: _e(306005, "DeleteMessageFailed", "消息撤回失败", "delete_message", True),
+    306006: _e(306006, "DeleteGetChannelFailed", "获取子频道失败", "delete_message", True),
+    306007: _e(306007, "DeleteWrongGroup", "非当前群的消息", "delete_message", False),
+    306008: _e(306008, "DeleteNotOwnBotMessage", "非当前机器人发送的消息", "delete_message", False),
+    306009: _e(306009, "DeleteNotCurrentUserDM", "非与当前用户发送的消息", "delete_message", False),
+    306010: _e(306010, "DeleteInternalError", "内部错误", "delete_message", True),
+    306011: _e(306011, "DeleteMessageExpired", "超出可撤回消息时间", "delete_message", False),
+    501001: _e(501001, "AnnouncementParamInvalid", "参数校验失败", "announce", False),
+    501002: _e(501002, "AnnouncementChannelCreateFailed", "创建子频道公告失败", "announce", True),
+    501003: _e(501003, "AnnouncementChannelDeleteFailed", "删除子频道公告失败", "announce", True),
+    501004: _e(501004, "AnnouncementGetGuildFailed", "获取频道信息失败", "announce", True),
+    501005: _e(501005, "AnnouncementMessageIdError", "MessageID 错误", "announce", False),
+    501006: _e(501006, "AnnouncementGuildCreateFailed", "创建频道全局公告失败", "announce", True),
+    501007: _e(501007, "AnnouncementGuildDeleteFailed", "删除频道全局公告失败", "announce", True),
+    501008: _e(501008, "AnnouncementMessageIdMissing", "MessageID 不存在", "announce", False),
+    501009: _e(501009, "AnnouncementMessageIdParseFailed", "MessageID 解析失败", "announce", False),
+    501010: _e(501010, "AnnouncementNotChannelMessage", "此条消息非子频道内消息", "announce", False),
+    501011: _e(501011, "PinMessageCreateFailed", "创建精华消息失败", "announce", True),
+    501012: _e(501012, "PinMessageDeleteFailed", "删除精华消息失败", "announce", True),
+    501013: _e(501013, "PinMessageLimit", "精华消息超过最大数量", "announce", False),
+    501014: _e(501014, "AnnouncementSafetyBlocked", "安全打击", "announce", False),
+    501015: _e(501015, "AnnouncementNotAllowed", "此消息不允许设置", "announce", False),
+    501016: _e(501016, "RecommendChannelLimit", "频道公告子频道推荐超过最大数量", "announce", False),
+    501017: _e(501017, "NotGuildOwnerOrAdmin", "非频道主或管理员", "announce", False),
+    501018: _e(501018, "RecommendChannelInvalid", "推荐子频道 ID 无效", "announce", False),
+    501019: _e(501019, "AnnouncementTypeError", "公告类型错误", "announce", False),
+    501020: _e(501020, "RecommendChannelAnnouncementCreateFailed", "创建推荐子频道类型频道公告失败", "announce", True),
+    502001: _e(502001, "MuteGuildIdInvalid", "频道 id 无效", "mute", False),
+    502002: _e(502002, "MuteGuildIdEmpty", "频道 id 为空", "mute", False),
+    502003: _e(502003, "MuteUserIdInvalid", "用户 id 无效", "mute", False),
+    502004: _e(502004, "MuteUserIdEmpty", "用户 id 为空", "mute", False),
+    502005: _e(502005, "MuteTimestampInvalid", "timestamp 不合法", "mute", False),
+    502006: _e(502006, "MuteTimestampWrong", "timestamp 无效", "mute", False),
+    502007: _e(502007, "MuteParamConvertError", "参数转换错误", "mute", False),
+    502008: _e(502008, "MuteRPCFailed", "rpc 调用失败", "mute", True),
+    502009: _e(502009, "MuteSafetyBlocked", "安全打击", "mute", False),
+    502010: _e(502010, "MuteHeaderError", "请求头错误", "mute", False),
+    503001: _e(503001, "ForumGuildIdInvalid", "频道 id 无效", "forum", False),
+    503002: _e(503002, "ForumGuildIdEmpty", "频道 id 为空", "forum", False),
+    503003: _e(503003, "ForumGetChannelFailed", "获取子频道信息失败", "forum", True),
+    503004: _e(503004, "ForumRateLimit", "超出发布帖子的频次限制", "forum", True),
+    503005: _e(503005, "ForumTitleEmpty", "帖子标题为空", "forum", False),
+    503006: _e(503006, "ForumContentEmpty", "帖子内容为空", "forum", False),
+    503007: _e(503007, "ForumPostIdEmpty", "帖子ID为空", "forum", False),
+    503008: _e(503008, "ForumGetXUinFailed", "获取X-Uin失败", "forum", True),
+    503009: _e(503009, "ForumPostIdInvalid", "帖子ID无效或不合法", "forum", False),
+    503010: _e(503010, "ForumTinyIdConvertFailed", "通过Uin获取TinyID失败", "forum", True),
+    503011: _e(503011, "ForumTimestampInvalid", "帖子ID时间戳无效或不合法", "forum", False),
+    503012: _e(503012, "ForumPostMissing", "帖子不存在或已删除", "forum", False),
+    503013: _e(503013, "ForumInternalError", "服务器内部错误", "forum", True),
+    503014: _e(503014, "ForumJsonParseFailed", "帖子JSON内容解析失败", "forum", False),
+    503015: _e(503015, "ForumContentConvertFailed", "帖子内容转换失败", "forum", False),
+    503016: _e(503016, "ForumLinkLimit", "链接数量超过限制", "forum", False),
+    503017: _e(503017, "ForumTextLimit", "字数超过限制", "forum", False),
+    503018: _e(503018, "ForumImageLimit", "图片数量超过限制", "forum", False),
+    503019: _e(503019, "ForumVideoLimit", "视频数量超过限制", "forum", False),
+    503020: _e(503020, "ForumTitleLimit", "标题长度超过限制", "forum", False),
+    504001: _e(504001, "RateLimitParamInvalid", "请求参数无效错误", "rate_limit", False),
+    504002: _e(504002, "RateLimitGetHeaderFailed", "获取 HTTP 头失败", "rate_limit", True),
+    504003: _e(504003, "RateLimitGetBotUinFailed", "获取 BOT UIN 错误", "rate_limit", True),
+    504004: _e(504004, "RateLimitSettingsFailed", "获取消息频率设置信息错误", "rate_limit", True),
+    610001: _e(610001, "APIPermissionGetGuildIdFailed", "获取频道 ID 失败", "guild_permission", True),
+    610002: _e(610002, "APIPermissionGetHeaderFailed", "获取 HTTP 头失败", "guild_permission", True),
+    610003: _e(610003, "APIPermissionGetBotNumberFailed", "获取机器人号码失败", "guild_permission", True),
+    610004: _e(610004, "APIPermissionGetBotRoleFailed", "获取机器人角色失败", "guild_permission", True),
+    610005: _e(610005, "APIPermissionGetBotRoleInternalError", "获取机器人角色内部错误", "guild_permission", True),
+    610006: _e(610006, "APIPermissionListFailed", "拉取机器人权限列表失败", "guild_permission", True),
+    610007: _e(610007, "BotNotInGuild", "机器人不在频道内", "guild_permission", False),
+    610008: _e(610008, "APIPermissionInvalidParam", "无效参数", "guild_permission", False),
+    610009: _e(610009, "APIPermissionDetailFailed", "获取 API 接口详情失败", "guild_permission", True),
+    610010: _e(610010, "APIPermissionAlreadyGranted", "API 接口已授权", "guild_permission", False),
+    610011: _e(610011, "APIPermissionBotInfoFailed", "获取机器人信息失败", "guild_permission", True),
+    610012: _e(610012, "APIPermissionRateLimitFailed", "限频失败", "guild_permission", True),
+    610013: _e(610013, "APIPermissionRateLimited", "已限频", "guild_permission", True),
+    610014: _e(610014, "APIPermissionLinkSendFailed", "api 授权链接发送失败", "guild_permission", True),
+    620001: _e(620001, "ReactionInvalidParam", "表情表态无效参数", "reaction", False),
+    620002: _e(620002, "ReactionTypeLimit", "表情反应类型数量上限", "reaction", False),
+    620003: _e(620003, "ReactionAlreadySet", "已经设置过该表情表态", "reaction", False),
+    620004: _e(620004, "ReactionNotSet", "没有设置过该表情表态", "reaction", False),
+    620005: _e(620005, "ReactionNoPermission", "没有权限设置表情表态", "reaction", False),
+    620006: _e(620006, "ReactionRateLimited", "操作限频", "reaction", True),
+    620007: _e(620007, "ReactionFailed", "表情表态操作失败", "reaction", True),
+    630001: _e(630001, "InteractionDataInvalidParam", "互动回调数据更新无效参数", "interaction", False),
+    630002: _e(630002, "InteractionDataGetAppIdFailed", "互动回调数据更新获取AppID失败", "interaction", True),
+    630003: _e(630003, "InteractionDataAppIdMismatch", "互动回调数据 AppID 不匹配", "interaction", False),
+    630004: _e(630004, "InteractionDataStoreFailed", "互动回调数据更新内部存储错误", "interaction", True),
+    630005: _e(630005, "InteractionDataStoreReadFailed", "互动回调数据更新内部存储读取错误", "interaction", True),
+    630006: _e(630006, "InteractionDataRequestAppIdFailed", "互动回调数据更新读取请求AppID失败", "interaction", True),
+    630007: _e(630007, "InteractionDataTooLarge", "互动回调数据太大", "interaction", False),
+    1100100: _e(1100100, "SAFE_RATE_LIMIT", "安全打击：消息被限频", "rate_limit", True),
+    1100101: _e(1100101, "SAFE_SENSITIVE", "安全打击：内容涉及敏感", "safety", False),
+    1100102: _e(1100102, "SAFE_NOT_ELIGIBLE", "暂未获得新功能体验资格", "permission", False),
+    1100103: _e(1100103, "SAFE_BLOCK", "安全打击", "safety", False),
+    1100104: _e(1100104, "GROUP_INVALID", "该群已失效或当前群已不存在", "resource", False),
+    1100300: _e(1100300, "INTERNAL_ERROR", "系统内部错误", "platform", True),
+    1100301: _e(1100301, "CALLER_NOT_GROUP_MEMBER", "调用方不是群成员", "permission", False),
+    1100302: _e(1100302, "GET_CHANNEL_NAME_FAILED", "获取指定频道名称失败", "platform", True),
+    1100303: _e(1100303, "NON_ADMIN_CANNOT_SPEAK", "主页频道非管理员不允许发消息", "permission", False),
+    1100304: _e(1100304, "AT_TIMES_AUTH_FAILED", "@次数鉴权失败", "platform", True),
+    1100305: _e(1100305, "TINYID_TO_UIN_FAILED", "TinyId 转换 Uin 失败", "platform", True),
+    1100306: _e(1100306, "NOT_PRIVATE_GUILD_MEMBER", "非私有频道成员", "permission", False),
+    1100307: _e(1100307, "NOT_WHITELIST_CHANNEL_APP", "非白名单应用子频道", "permission", False),
+    1100308: _e(1100308, "CHANNEL_RATE_LIMIT", "触发频道内限频", "rate_limit", True),
+    1100499: _e(1100499, "OTHER_SEND_ERROR", "其他错误", "send", True),
+    3300006: _e(3300006, "EDIT_MESSAGE_SAFETY_BLOCK", "编辑消息安全打击", "edit_message", False),
+}
+
+KNOWN_ERROR_RANGES: tuple[tuple[range, str, str, bool], ...] = (
+    (range(301000, 301100), "channel_permission", "子频道权限错误", False),
+    (range(302000, 302100), "schedule", "日程相关错误", False),
+    (range(304000, 304100), "send", "消息发送相关错误", False),
+    (range(306001, 306012), "delete_message", "撤回消息错误", True),
+    (range(501000, 502000), "announce", "公告错误", True),
+    (range(502000, 503000), "mute", "禁言相关错误", True),
+    (range(503000, 504000), "forum", "帖子/论坛相关错误", False),
+    (range(504000, 505000), "rate_limit", "消息频率相关错误", True),
+    (range(610000, 620000), "guild_permission", "频道权限错误", False),
+    (range(620000, 630000), "reaction", "表情表态错误", False),
+    (range(630000, 640000), "interaction", "互动回调数据更新错误", True),
+    (range(1000000, 3000000), "send", "发消息错误", False),
+    (range(3000000, 4000000), "edit_message", "编辑消息错误", False),
+)
+
+
+def build_openapi_error(
+    response: httpx.Response,
+    payload: Any,
+    *,
+    default_message: str | None = None,
+) -> QQOpenAPIError:
+    error_code = extract_business_code(payload)
+    known = lookup_known_error(error_code)
+    error_message = default_message or response.reason_phrase or http_status_description(response.status_code)
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload.get("msg")
+        if message:
+            error_message = str(message)
+    elif isinstance(payload, str) and payload.strip():
+        error_message = payload.strip()
+    elif known is not None:
+        error_message = known.description
+
+    return QQOpenAPIError(
+        status_code=response.status_code,
+        trace_id=trace_id_from_response(response),
+        error_code=error_code,
+        error_message=error_message,
+        response_body=payload,
+        known=known,
+    )
+
+
+def trace_id_from_response(response: httpx.Response) -> str | None:
+    trace_id = response.headers.get("X-Tps-trace-ID", "").strip()
+    return trace_id or None
+
+
+def http_status_description(status_code: int) -> str:
+    return HTTP_STATUS_DESCRIPTIONS.get(status_code, "request failed")
+
+
+def lookup_known_error(error_code: int | None) -> QQKnownOpenAPIError | None:
+    if error_code is None:
+        return None
+    known = KNOWN_OPENAPI_ERRORS.get(error_code)
+    if known is not None:
+        return known
+    for code_range, category, description, retryable in KNOWN_ERROR_RANGES:
+        if error_code in code_range:
+            return QQKnownOpenAPIError(
+                code=error_code,
+                name=f"{category.upper()}_{error_code}",
+                description=description,
+                category=category,
+                retryable=retryable,
+            )
+    return None
+
+
+def extract_business_code(payload: Any) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("code")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/packages/bub-qq/src/bub_qq/openapi_errors.py
+++ b/packages/bub-qq/src/bub_qq/openapi_errors.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
-
-import httpx
+from typing import Protocol
 
 
 def _e(
@@ -54,6 +54,12 @@ class QQOpenAPIError(RuntimeError):
             parts.append(self.known.name)
         parts.append(self.error_message)
         return "qq openapi error: " + " ".join(parts)
+
+
+class ResponseLike(Protocol):
+    status: int
+    reason: str
+    headers: Mapping[str, str]
 
 
 HTTP_STATUS_DESCRIPTIONS: dict[int, str] = {
@@ -330,14 +336,14 @@ KNOWN_ERROR_RANGES: tuple[tuple[range, str, str, bool], ...] = (
 
 
 def build_openapi_error(
-    response: httpx.Response,
+    response: ResponseLike,
     payload: Any,
     *,
     default_message: str | None = None,
 ) -> QQOpenAPIError:
     error_code = extract_business_code(payload)
     known = lookup_known_error(error_code)
-    error_message = default_message or response.reason_phrase or http_status_description(response.status_code)
+    error_message = default_message or response.reason or http_status_description(response.status)
     if isinstance(payload, dict):
         message = payload.get("message") or payload.get("msg")
         if message:
@@ -348,7 +354,7 @@ def build_openapi_error(
         error_message = known.description
 
     return QQOpenAPIError(
-        status_code=response.status_code,
+        status_code=response.status,
         trace_id=trace_id_from_response(response),
         error_code=error_code,
         error_message=error_message,
@@ -357,7 +363,7 @@ def build_openapi_error(
     )
 
 
-def trace_id_from_response(response: httpx.Response) -> str | None:
+def trace_id_from_response(response: ResponseLike) -> str | None:
     trace_id = response.headers.get("X-Tps-trace-ID", "").strip()
     return trace_id or None
 

--- a/packages/bub-qq/src/bub_qq/plugin.py
+++ b/packages/bub-qq/src/bub_qq/plugin.py
@@ -1,0 +1,10 @@
+from bub import hookimpl
+from bub.channels import Channel
+from bub.types import MessageHandler
+
+
+@hookimpl
+def provide_channels(message_handler: MessageHandler) -> list[Channel]:
+    from .channel import QQChannel
+
+    return [QQChannel(message_handler)]

--- a/packages/bub-qq/src/bub_qq/send_errors.py
+++ b/packages/bub-qq/src/bub_qq/send_errors.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from loguru import logger
+
+from .openapi_errors import QQOpenAPIError
+
+
+def log_send_error(
+    exc: QQOpenAPIError,
+    *,
+    session_id: str,
+    openid: str,
+    msg_id: str,
+    msg_seq: int,
+    receive_mode: str,
+) -> None:
+    code = exc.error_code
+    trace_id = exc.trace_id or "-"
+    if code == 304027:
+        logger.warning(
+            "qq.send failed session_id={} openid={} msg_id={} msg_seq={} reason=reply_expired trace_id={}",
+            session_id,
+            openid,
+            msg_id,
+            msg_seq,
+            trace_id,
+        )
+        return
+    if code == 304031:
+        logger.warning(
+            "qq.send failed session_id={} openid={} reason=dm_closed trace_id={}",
+            session_id,
+            openid,
+            trace_id,
+        )
+        return
+    if code in {22009, 20028, 304045, 304049, 1100100, 1100308}:
+        logger.warning(
+            "qq.send failed session_id={} openid={} msg_id={} msg_seq={} reason=rate_limited code={} retryable={} trace_id={}",
+            session_id,
+            openid,
+            msg_id,
+            msg_seq,
+            code,
+            exc.known.retryable if exc.known is not None else False,
+            trace_id,
+        )
+        return
+    if code == 304018:
+        logger.warning(
+            "qq.send failed session_id={} openid={} reason=gateway_session_missing receive_mode={} trace_id={}",
+            session_id,
+            openid,
+            receive_mode,
+            trace_id,
+        )
+        return
+    if code in {304026, 50048}:
+        logger.warning(
+            "qq.send failed session_id={} openid={} reason=invalid_reply_message_id msg_id={} msg_seq={} trace_id={}",
+            session_id,
+            openid,
+            msg_id,
+            msg_seq,
+            trace_id,
+        )
+        return
+    if code in {304028, 50045, 50046, 50047}:
+        logger.warning(
+            "qq.send failed session_id={} openid={} reason=reply_not_allowed code={} msg_id={} trace_id={}",
+            session_id,
+            openid,
+            code,
+            msg_id,
+            trace_id,
+        )
+        return
+    if code in {304025, 1100101, 1100102, 1100103}:
+        logger.warning(
+            "qq.send failed session_id={} openid={} reason=safety_blocked code={} trace_id={}",
+            session_id,
+            openid,
+            code,
+            trace_id,
+        )
+        return
+    logger.error(
+        "qq.send failed session_id={} openid={} msg_id={} msg_seq={} code={} trace_id={} error={}",
+        session_id,
+        openid,
+        msg_id,
+        msg_seq,
+        code,
+        trace_id,
+        exc,
+    )

--- a/packages/bub-qq/src/bub_qq/send_errors.py
+++ b/packages/bub-qq/src/bub_qq/send_errors.py
@@ -5,6 +5,32 @@ from loguru import logger
 from .openapi_errors import QQOpenAPIError
 
 
+def is_duplicate_send_error(exc: QQOpenAPIError) -> bool:
+    return exc.error_code == 40054005
+
+
+def log_send_duplicate_error(
+    exc: QQOpenAPIError,
+    *,
+    session_id: str,
+    openid: str,
+    msg_id: str,
+    msg_seq: int,
+    content_hash: str,
+) -> None:
+    logger.warning(
+        "qq.send failed session_id={} openid={} msg_id={} msg_seq={} reason=already_sent source=remote_dedup_hit code={} trace_id={} content_hash={} error={}",
+        session_id,
+        openid,
+        msg_id,
+        msg_seq,
+        exc.error_code,
+        exc.trace_id or "-",
+        content_hash,
+        exc.error_message,
+    )
+
+
 def log_send_error(
     exc: QQOpenAPIError,
     *,
@@ -16,6 +42,16 @@ def log_send_error(
 ) -> None:
     code = exc.error_code
     trace_id = exc.trace_id or "-"
+    if is_duplicate_send_error(exc):
+        log_send_duplicate_error(
+            exc,
+            session_id=session_id,
+            openid=openid,
+            msg_id=msg_id,
+            msg_seq=msg_seq,
+            content_hash="-",
+        )
+        return
     if code == 304027:
         logger.warning(
             "qq.send failed session_id={} openid={} msg_id={} msg_seq={} reason=reply_expired trace_id={}",

--- a/packages/bub-qq/src/bub_qq/signature.py
+++ b/packages/bub-qq/src/bub_qq/signature.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+
+def _seed_from_secret(secret: str) -> bytes:
+    seed = secret
+    while len(seed) < 32:
+        seed = seed * 2
+    return seed[:32].encode("utf-8")
+
+
+def derive_public_key(secret: str) -> Ed25519PublicKey:
+    """Derive the public key from QQ bot secret using the documented seed rule."""
+
+    private_key = Ed25519PrivateKey.from_private_bytes(_seed_from_secret(secret))
+    return private_key.public_key()
+
+
+def sign_validation_payload(*, secret: str, event_ts: str, plain_token: str) -> str:
+    """Sign webhook validation payload as documented by QQ."""
+
+    private_key = Ed25519PrivateKey.from_private_bytes(_seed_from_secret(secret))
+    signature = private_key.sign(f"{event_ts}{plain_token}".encode("utf-8"))
+    return signature.hex()
+
+
+def verify_request_signature(
+    *,
+    secret: str,
+    timestamp: str,
+    body: bytes,
+    signature_hex: str,
+) -> bool:
+    """Verify the QQ webhook request signature over timestamp + raw body."""
+
+    if not timestamp or not signature_hex:
+        return False
+
+    try:
+        signature = bytes.fromhex(signature_hex)
+    except ValueError:
+        return False
+
+    if len(signature) != 64 or (signature[63] & 224) != 0:
+        return False
+
+    message = timestamp.encode("utf-8") + body
+    public_key = derive_public_key(secret)
+    try:
+        public_key.verify(signature, message)
+    except InvalidSignature:
+        return False
+    return True

--- a/packages/bub-qq/src/bub_qq/webhook.py
+++ b/packages/bub-qq/src/bub_qq/webhook.py
@@ -105,14 +105,7 @@ class QQWebhookServer:
             self._write_json(handler, HTTPStatus.SERVICE_UNAVAILABLE, {"error": "loop not ready"})
             return
 
-        future = asyncio.run_coroutine_threadsafe(self._on_payload(payload), self._loop)
-        try:
-            future.result(timeout=self._config.webhook_callback_timeout_seconds)
-        except Exception as exc:
-            logger.exception("qq.webhook.callback_failed op={} t={}", payload.get("op"), payload.get("t"))
-            self._write_json(handler, HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
-            return
-
+        self._schedule_payload(payload)
         self._write_json(handler, HTTPStatus.OK, {"op": 12})
 
     def _handle_validation(
@@ -164,6 +157,25 @@ class QQWebhookServer:
             body=body,
             signature_hex=signature,
         )
+
+    def _schedule_payload(self, payload: dict[str, Any]) -> None:
+        if self._loop is None:
+            raise RuntimeError("qq webhook loop not ready")
+
+        future = asyncio.run_coroutine_threadsafe(self._on_payload(payload), self._loop)
+        future.add_done_callback(
+            lambda task: self._log_callback_result(
+                task,
+                op=payload.get("op"),
+                event_type=payload.get("t"),
+            )
+        )
+
+    def _log_callback_result(self, future: Any, *, op: Any, event_type: Any) -> None:
+        try:
+            future.result()
+        except Exception:
+            logger.exception("qq.webhook.callback_failed op={} t={}", op, event_type)
 
     def _write_json(
         self,

--- a/packages/bub-qq/src/bub_qq/webhook.py
+++ b/packages/bub-qq/src/bub_qq/webhook.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections.abc import Callable, Coroutine
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from loguru import logger
+
+from .config import QQConfig
+from .signature import sign_validation_payload
+from .signature import verify_request_signature
+
+WebhookCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class QQWebhookServer:
+    """Embedded HTTP webhook receiver for QQ callback events."""
+
+    def __init__(
+        self,
+        config: QQConfig,
+        on_payload: WebhookCallback,
+    ) -> None:
+        self._config = config
+        self._on_payload = on_payload
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    async def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._loop = asyncio.get_running_loop()
+        handler = self._build_handler()
+        self._server = ThreadingHTTPServer(
+            (self._config.webhook_host, self._config.webhook_port),
+            handler,
+        )
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="qq-webhook-server",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "qq.webhook.start host={} port={} path={}",
+            self._config.webhook_host,
+            self._config.webhook_port,
+            self._config.webhook_path,
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+        logger.info("qq.webhook.stopped")
+
+    def _build_handler(self) -> type[BaseHTTPRequestHandler]:
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                parent._handle_post(self)
+
+            def log_message(self, format: str, *args: Any) -> None:
+                logger.debug("qq.webhook.http " + format, *args)
+
+        return Handler
+
+    def _handle_post(self, handler: BaseHTTPRequestHandler) -> None:
+        if handler.path != self._config.webhook_path:
+            self._write_json(handler, HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        try:
+            body = self._read_body(handler)
+        except ValueError as exc:
+            self._write_json(handler, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        if self._config.verify_signature and not self._is_signature_valid(handler, body):
+            self._write_json(handler, HTTPStatus.UNAUTHORIZED, {"error": "invalid signature"})
+            return
+
+        try:
+            payload = self._parse_json(body)
+        except ValueError as exc:
+            self._write_json(handler, HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        op = payload.get("op")
+        if op == 13:
+            self._handle_validation(handler, payload)
+            return
+
+        if self._loop is None:
+            self._write_json(handler, HTTPStatus.SERVICE_UNAVAILABLE, {"error": "loop not ready"})
+            return
+
+        future = asyncio.run_coroutine_threadsafe(self._on_payload(payload), self._loop)
+        try:
+            future.result(timeout=self._config.webhook_callback_timeout_seconds)
+        except Exception as exc:
+            logger.exception("qq.webhook.callback_failed op={} t={}", payload.get("op"), payload.get("t"))
+            self._write_json(handler, HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+            return
+
+        self._write_json(handler, HTTPStatus.OK, {"op": 12})
+
+    def _handle_validation(
+        self,
+        handler: BaseHTTPRequestHandler,
+        payload: dict[str, Any],
+    ) -> None:
+        data = payload.get("d")
+        if not isinstance(data, dict):
+            self._write_json(handler, HTTPStatus.BAD_REQUEST, {"error": "payload.d must be an object"})
+            return
+
+        plain_token = str(data.get("plain_token") or "")
+        event_ts = str(data.get("event_ts") or "")
+        if not plain_token or not event_ts:
+            self._write_json(handler, HTTPStatus.BAD_REQUEST, {"error": "validation payload incomplete"})
+            return
+
+        signature = sign_validation_payload(
+            secret=self._config.secret,
+            event_ts=event_ts,
+            plain_token=plain_token,
+        )
+        self._write_json(
+            handler,
+            HTTPStatus.OK,
+            {"plain_token": plain_token, "signature": signature},
+        )
+
+    def _read_body(self, handler: BaseHTTPRequestHandler) -> bytes:
+        content_length = int(handler.headers.get("Content-Length", "0"))
+        return handler.rfile.read(content_length)
+
+    def _parse_json(self, body: bytes) -> dict[str, Any]:
+        payload = json.loads(body.decode("utf-8") or "{}")
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be a JSON object")
+        return payload
+
+    def _is_signature_valid(self, handler: BaseHTTPRequestHandler, body: bytes) -> bool:
+        signature = handler.headers.get("X-Signature-Ed25519", "")
+        timestamp = handler.headers.get("X-Signature-Timestamp", "")
+        if not signature or not timestamp:
+            logger.warning("qq.webhook.signature_missing")
+            return False
+        return verify_request_signature(
+            secret=self._config.secret,
+            timestamp=timestamp,
+            body=body,
+            signature_hex=signature,
+        )
+
+    def _write_json(
+        self,
+        handler: BaseHTTPRequestHandler,
+        status: HTTPStatus,
+        payload: dict[str, Any],
+    ) -> None:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        handler.send_response(status)
+        handler.send_header("Content-Type", "application/json; charset=utf-8")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        handler.wfile.write(body)

--- a/packages/bub-qq/src/bub_qq/websocket.py
+++ b/packages/bub-qq/src/bub_qq/websocket.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
-from collections.abc import Callable, Coroutine
+import time
+from collections import deque
+from collections.abc import Awaitable
+from collections.abc import Callable
+from collections.abc import Coroutine
+from dataclasses import dataclass
 from typing import Any
 
 import aiohttp
@@ -11,6 +16,7 @@ from loguru import logger
 
 from .auth import QQAuthError
 from .config import QQConfig
+from .gateway import QQGatewayInfo
 from .gateway import get_gateway
 from .gateway import get_shard_gateway
 from .gateway import heartbeat_payload
@@ -24,6 +30,34 @@ from .ws_errors import raise_for_close_code
 WebSocketCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
 
 
+@dataclass(frozen=True)
+class _ShardSpec:
+    index: int
+    total: int
+    url: str
+    use_shard: bool
+    max_concurrency: int | None = None
+
+    @property
+    def shard(self) -> tuple[int, int] | None:
+        if not self.use_shard:
+            return None
+        return (self.index, self.total)
+
+    @property
+    def label(self) -> str:
+        if not self.use_shard:
+            return "single"
+        return f"{self.index}/{self.total}"
+
+
+@dataclass
+class _ShardState:
+    sequence: int | None = None
+    session_id: str | None = None
+    heartbeat_task: asyncio.Task[None] | None = None
+
+
 class QQWebSocketClient:
     """QQ gateway websocket receiver."""
 
@@ -32,18 +66,23 @@ class QQWebSocketClient:
         config: QQConfig,
         openapi: QQOpenAPI,
         on_payload: WebSocketCallback,
+        *,
+        monotonic: Callable[[], float] | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
         self._config = config
         self._openapi = openapi
         self._on_payload = on_payload
         self._task: asyncio.Task[None] | None = None
         self._stop_event: asyncio.Event | None = None
-        self._sequence: int | None = None
-        self._session_id: str | None = None
-        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._shard_states: dict[int, _ShardState] = {}
+        self._identify_lock: asyncio.Lock | None = None
+        self._identify_attempts: deque[float] = deque()
+        self._monotonic = monotonic or time.monotonic
+        self._sleep = sleep
 
     async def start(self, stop_event: asyncio.Event | None = None) -> None:
-        if self._task is not None:
+        if self._task is not None and not self._task.done():
             return
         self._stop_event = stop_event or asyncio.Event()
         self._task = asyncio.create_task(self._run())
@@ -51,38 +90,21 @@ class QQWebSocketClient:
     async def stop(self) -> None:
         if self._stop_event is not None:
             self._stop_event.set()
-        if self._heartbeat_task is not None:
-            self._heartbeat_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._heartbeat_task
-            self._heartbeat_task = None
         if self._task is not None:
             self._task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._task
             self._task = None
+        self._shard_states.clear()
+        self._identify_attempts.clear()
         logger.info("qq.websocket.stopped")
 
     async def _run(self) -> None:
-        while not (self._stop_event and self._stop_event.is_set()):
+        while not self._should_stop():
             try:
-                await self._connect_once()
+                specs = await self._resolve_shard_specs()
             except asyncio.CancelledError:
                 raise
-            except QQWebSocketFatalError as exc:
-                logger.error("qq.websocket.fatal code={} message={}", exc.code, exc)
-                if self._stop_event is not None:
-                    self._stop_event.set()
-                break
-            except QQWebSocketReconnectRequested:
-                logger.warning(
-                    "qq.websocket.reconnect_requested reason=server_requested_reconnect delay_seconds={}",
-                    self._config.websocket_reconnect_delay_seconds,
-                )
-            except QQWebSocketInvalidSession:
-                logger.warning("qq.websocket.invalid_session action=identify_from_scratch")
-                self._session_id = None
-                self._sequence = None
             except (QQAuthError, QQOpenAPIError) as exc:
                 if _is_permanent_connect_error(exc):
                     logger.error("qq.websocket.permanent_error error={}", exc)
@@ -92,39 +114,138 @@ class QQWebSocketClient:
                 logger.warning("qq.websocket.error error={}", exc)
             except Exception as exc:
                 logger.warning("qq.websocket.error error={}", exc)
-            if self._stop_event and self._stop_event.is_set():
+            else:
+                self._reset_shard_states(specs)
+                await self._run_workers(specs)
                 break
-            await asyncio.sleep(self._config.websocket_reconnect_delay_seconds)
 
-    async def _connect_once(self) -> None:
+            if self._should_stop():
+                break
+            await self._sleep(self._config.websocket_reconnect_delay_seconds)
+
+    async def _run_workers(self, specs: list[_ShardSpec]) -> None:
+        try:
+            async with asyncio.TaskGroup() as task_group:
+                task_group.create_task(self._watch_stop_event())
+                for spec in specs:
+                    task_group.create_task(self._run_shard(spec))
+        except* QQWebSocketStopRequested:
+            pass
+        except* QQWebSocketFatalError:
+            if self._stop_event is not None:
+                self._stop_event.set()
+        except* QQAuthError:
+            if self._stop_event is not None:
+                self._stop_event.set()
+        except* QQOpenAPIError:
+            if self._stop_event is not None:
+                self._stop_event.set()
+
+    async def _watch_stop_event(self) -> None:
+        if self._stop_event is None:
+            return
+        await self._stop_event.wait()
+        raise QQWebSocketStopRequested()
+
+    async def _resolve_shard_specs(self) -> list[_ShardSpec]:
         gateway = (
             await get_shard_gateway(self._openapi)
             if self._config.websocket_use_shard_gateway
             else await get_gateway(self._openapi)
         )
+        return self._build_shard_specs(gateway)
+
+    def _build_shard_specs(self, gateway: QQGatewayInfo) -> list[_ShardSpec]:
+        if not self._config.websocket_use_shard_gateway:
+            return [_ShardSpec(index=0, total=1, url=gateway.url, use_shard=False)]
+
+        total = gateway.shards or 1
+        if total < 1:
+            total = 1
+        return [
+            _ShardSpec(
+                index=index,
+                total=total,
+                url=gateway.url,
+                use_shard=True,
+                max_concurrency=gateway.max_concurrency,
+            )
+            for index in range(total)
+        ]
+
+    def _reset_shard_states(self, specs: list[_ShardSpec]) -> None:
+        self._shard_states = {spec.index: _ShardState() for spec in specs}
+        self._identify_attempts.clear()
+
+    async def _run_shard(self, spec: _ShardSpec) -> None:
+        while not self._should_stop():
+            try:
+                await self._connect_once(spec)
+            except asyncio.CancelledError:
+                raise
+            except QQWebSocketFatalError as exc:
+                logger.error(
+                    "qq.websocket.fatal shard={} code={} message={}",
+                    spec.label,
+                    exc.code,
+                    exc,
+                )
+                raise
+            except QQWebSocketReconnectRequested:
+                logger.warning(
+                    "qq.websocket.reconnect_requested shard={} reason=server_requested_reconnect delay_seconds={}",
+                    spec.label,
+                    self._config.websocket_reconnect_delay_seconds,
+                )
+            except QQWebSocketInvalidSession:
+                logger.warning(
+                    "qq.websocket.invalid_session shard={} action=identify_from_scratch",
+                    spec.label,
+                )
+                state = self._shard_states[spec.index]
+                state.session_id = None
+                state.sequence = None
+            except (QQAuthError, QQOpenAPIError) as exc:
+                if _is_permanent_connect_error(exc):
+                    logger.error(
+                        "qq.websocket.permanent_error shard={} error={}",
+                        spec.label,
+                        exc,
+                    )
+                    raise
+                logger.warning("qq.websocket.error shard={} error={}", spec.label, exc)
+            except Exception as exc:
+                logger.warning("qq.websocket.error shard={} error={}", spec.label, exc)
+
+            if self._should_stop():
+                break
+            await self._sleep(self._config.websocket_reconnect_delay_seconds)
+
+    async def _connect_once(self, spec: _ShardSpec) -> None:
+        state = self._shard_states[spec.index]
         timeout = aiohttp.ClientTimeout(total=None, sock_connect=self._config.timeout_seconds)
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.ws_connect(gateway.url, heartbeat=None) as ws:
-                logger.info("qq.websocket.connected url={}", gateway.url)
+            async with session.ws_connect(spec.url, heartbeat=None) as ws:
+                logger.info("qq.websocket.connected shard={} url={}", spec.label, spec.url)
                 heartbeat_interval = await self._await_hello(ws)
-                await self._identify_or_resume(ws, gateway)
-                self._heartbeat_task = asyncio.create_task(
-                    self._heartbeat_loop(ws, heartbeat_interval)
+                await self._identify_or_resume(ws, spec, state)
+                state.heartbeat_task = asyncio.create_task(
+                    self._heartbeat_loop(ws, state, heartbeat_interval)
                 )
                 try:
                     async for message in ws:
                         if message.type == aiohttp.WSMsgType.TEXT:
-                            await self._handle_text_frame(ws, message.data)
+                            await self._handle_text_frame(ws, spec, state, message.data)
                         elif message.type == aiohttp.WSMsgType.ERROR:
                             raise RuntimeError(f"qq websocket error frame: {ws.exception()}")
                         elif message.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED}:
                             break
                 finally:
-                    if self._heartbeat_task is not None:
-                        self._heartbeat_task.cancel()
+                    if state.heartbeat_task is not None:
+                        state.heartbeat_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
-                            await self._heartbeat_task
-                        self._heartbeat_task = None
+                            await state.heartbeat_task
+                        state.heartbeat_task = None
                 raise_for_close_code(ws.close_code)
 
     async def _await_hello(self, ws: aiohttp.ClientWebSocketResponse) -> float:
@@ -135,7 +256,6 @@ class QQWebSocketClient:
             payload = _parse_payload(message.data)
             op = payload.get("op")
             if op != 10:
-                await self._dispatch_if_needed(payload)
                 continue
             data = payload.get("d")
             if not isinstance(data, dict) or "heartbeat_interval" not in data:
@@ -146,47 +266,70 @@ class QQWebSocketClient:
     async def _identify_or_resume(
         self,
         ws: aiohttp.ClientWebSocketResponse,
-        gateway: Any,
+        spec: _ShardSpec,
+        state: _ShardState,
     ) -> None:
         token = await self._openapi.get_access_token()
-        if self._session_id and self._sequence is not None:
+        if state.session_id and state.sequence is not None:
             logger.info(
-                "qq.websocket.resume_attempt session_id={} seq={}",
-                self._session_id,
-                self._sequence,
+                "qq.websocket.resume_attempt shard={} session_id={} seq={}",
+                spec.label,
+                state.session_id,
+                state.sequence,
             )
             await ws.send_json(
                 resume_payload(
                     token=token,
-                    session_id=self._session_id,
-                    sequence=self._sequence,
+                    session_id=state.session_id,
+                    sequence=state.sequence,
                 )
             )
             return
 
-        shard: tuple[int, int] | None = None
-        if self._config.websocket_use_shard_gateway and getattr(gateway, "shards", None):
-            shard = (0, int(gateway.shards))
+        await self._await_identify_slot(spec.max_concurrency)
         await ws.send_json(
             identify_payload(
                 token=token,
                 intents=self._config.websocket_intents,
-                shard=shard,
+                shard=spec.shard,
             )
         )
+
+    async def _await_identify_slot(self, max_concurrency: int | None) -> None:
+        if max_concurrency is None or max_concurrency < 1:
+            return
+        while True:
+            lock = self._get_identify_lock()
+            async with lock:
+                now = self._monotonic()
+                while self._identify_attempts and now - self._identify_attempts[0] >= 5.0:
+                    self._identify_attempts.popleft()
+                if len(self._identify_attempts) < max_concurrency:
+                    self._identify_attempts.append(now)
+                    return
+                wait_seconds = max(0.0, 5.0 - (now - self._identify_attempts[0]))
+            await self._sleep(wait_seconds)
+
+    def _get_identify_lock(self) -> asyncio.Lock:
+        if self._identify_lock is None:
+            self._identify_lock = asyncio.Lock()
+        return self._identify_lock
 
     async def _heartbeat_loop(
         self,
         ws: aiohttp.ClientWebSocketResponse,
+        state: _ShardState,
         interval_seconds: float,
     ) -> None:
         while True:
             await asyncio.sleep(interval_seconds)
-            await ws.send_json(heartbeat_payload(self._sequence))
+            await ws.send_json(heartbeat_payload(state.sequence))
 
     async def _handle_text_frame(
         self,
         ws: aiohttp.ClientWebSocketResponse,
+        spec: _ShardSpec,
+        state: _ShardState,
         text: str,
     ) -> None:
         payload = _parse_payload(text)
@@ -198,16 +341,21 @@ class QQWebSocketClient:
         if op == 9:
             raise QQWebSocketInvalidSession()
         if op == 1:
-            await ws.send_json(heartbeat_payload(self._sequence))
+            await ws.send_json(heartbeat_payload(state.sequence))
             return
-        await self._dispatch_if_needed(payload)
+        await self._dispatch_if_needed(spec, state, payload)
 
-    async def _dispatch_if_needed(self, payload: dict[str, Any]) -> None:
+    async def _dispatch_if_needed(
+        self,
+        spec: _ShardSpec,
+        state: _ShardState,
+        payload: dict[str, Any],
+    ) -> None:
         if payload.get("s") is not None:
             try:
-                self._sequence = int(payload["s"])
+                state.sequence = int(payload["s"])
             except (TypeError, ValueError):
-                self._sequence = self._sequence
+                state.sequence = state.sequence
         if payload.get("op") == 0:
             event_type = payload.get("t")
             if event_type == "READY":
@@ -215,11 +363,17 @@ class QQWebSocketClient:
                 if isinstance(data, dict):
                     session_id = data.get("session_id")
                     if isinstance(session_id, str) and session_id.strip():
-                        self._session_id = session_id.strip()
-            elif event_type == "RESUMED" and self._session_id:
-                logger.info("qq.websocket.resume_succeeded session_id={}", self._session_id)
-        if payload.get("op") == 0:
+                        state.session_id = session_id.strip()
+            elif event_type == "RESUMED" and state.session_id:
+                logger.info(
+                    "qq.websocket.resume_succeeded shard={} session_id={}",
+                    spec.label,
+                    state.session_id,
+                )
             await self._on_payload(payload)
+
+    def _should_stop(self) -> bool:
+        return self._stop_event is not None and self._stop_event.is_set()
 
 
 def _parse_payload(text: str) -> dict[str, Any]:
@@ -237,6 +391,11 @@ class QQWebSocketReconnectRequested(RuntimeError):
 class QQWebSocketInvalidSession(RuntimeError):
     def __init__(self) -> None:
         super().__init__("qq websocket invalid session")
+
+
+class QQWebSocketStopRequested(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("qq websocket stop requested")
 
 
 def _is_permanent_connect_error(exc: QQAuthError | QQOpenAPIError) -> bool:

--- a/packages/bub-qq/src/bub_qq/websocket.py
+++ b/packages/bub-qq/src/bub_qq/websocket.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import aiohttp
+from loguru import logger
+
+from .config import QQConfig
+from .gateway import get_gateway
+from .gateway import get_shard_gateway
+from .gateway import heartbeat_payload
+from .gateway import identify_payload
+from .gateway import resume_payload
+from .openapi import QQOpenAPI
+from .ws_errors import QQWebSocketFatalError
+from .ws_errors import raise_for_close_code
+
+WebSocketCallback = Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+
+
+class QQWebSocketClient:
+    """QQ gateway websocket receiver."""
+
+    def __init__(
+        self,
+        config: QQConfig,
+        openapi: QQOpenAPI,
+        on_payload: WebSocketCallback,
+    ) -> None:
+        self._config = config
+        self._openapi = openapi
+        self._on_payload = on_payload
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event | None = None
+        self._sequence: int | None = None
+        self._session_id: str | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+    async def start(self, stop_event: asyncio.Event | None = None) -> None:
+        if self._task is not None:
+            return
+        self._stop_event = stop_event or asyncio.Event()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._stop_event is not None:
+            self._stop_event.set()
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._heartbeat_task
+            self._heartbeat_task = None
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        logger.info("qq.websocket.stopped")
+
+    async def _run(self) -> None:
+        while not (self._stop_event and self._stop_event.is_set()):
+            try:
+                await self._connect_once()
+            except asyncio.CancelledError:
+                raise
+            except QQWebSocketFatalError as exc:
+                logger.error("qq.websocket.fatal code={} message={}", exc.code, exc)
+                if self._stop_event is not None:
+                    self._stop_event.set()
+                break
+            except QQWebSocketReconnectRequested:
+                logger.warning(
+                    "qq.websocket.reconnect_requested reason=server_requested_reconnect delay_seconds={}",
+                    self._config.websocket_reconnect_delay_seconds,
+                )
+            except QQWebSocketInvalidSession:
+                logger.warning("qq.websocket.invalid_session action=identify_from_scratch")
+                self._session_id = None
+                self._sequence = None
+            except Exception as exc:
+                logger.warning("qq.websocket.error error={}", exc)
+            if self._stop_event and self._stop_event.is_set():
+                break
+            await asyncio.sleep(self._config.websocket_reconnect_delay_seconds)
+
+    async def _connect_once(self) -> None:
+        gateway = (
+            await get_shard_gateway(self._openapi)
+            if self._config.websocket_use_shard_gateway
+            else await get_gateway(self._openapi)
+        )
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=self._config.timeout_seconds)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.ws_connect(gateway.url, heartbeat=None) as ws:
+                logger.info("qq.websocket.connected url={}", gateway.url)
+                heartbeat_interval = await self._await_hello(ws)
+                await self._identify_or_resume(ws, gateway)
+                self._heartbeat_task = asyncio.create_task(
+                    self._heartbeat_loop(ws, heartbeat_interval)
+                )
+                try:
+                    async for message in ws:
+                        if message.type == aiohttp.WSMsgType.TEXT:
+                            await self._handle_text_frame(ws, message.data)
+                        elif message.type == aiohttp.WSMsgType.ERROR:
+                            raise RuntimeError(f"qq websocket error frame: {ws.exception()}")
+                        elif message.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED}:
+                            break
+                finally:
+                    if self._heartbeat_task is not None:
+                        self._heartbeat_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await self._heartbeat_task
+                        self._heartbeat_task = None
+                raise_for_close_code(ws.close_code)
+
+    async def _await_hello(self, ws: aiohttp.ClientWebSocketResponse) -> float:
+        while True:
+            message = await ws.receive()
+            if message.type != aiohttp.WSMsgType.TEXT:
+                raise RuntimeError(f"qq websocket expected hello text frame, got {message.type}")
+            payload = _parse_payload(message.data)
+            op = payload.get("op")
+            if op != 10:
+                await self._dispatch_if_needed(payload)
+                continue
+            data = payload.get("d")
+            if not isinstance(data, dict) or "heartbeat_interval" not in data:
+                raise RuntimeError("qq websocket hello missing heartbeat_interval")
+            interval_ms = float(data["heartbeat_interval"])
+            return interval_ms / 1000.0
+
+    async def _identify_or_resume(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        gateway: Any,
+    ) -> None:
+        token = await self._openapi.get_access_token()
+        if self._session_id and self._sequence is not None:
+            logger.info(
+                "qq.websocket.resume_attempt session_id={} seq={}",
+                self._session_id,
+                self._sequence,
+            )
+            await ws.send_json(
+                resume_payload(
+                    token=token,
+                    session_id=self._session_id,
+                    sequence=self._sequence,
+                )
+            )
+            return
+
+        shard: tuple[int, int] | None = None
+        if self._config.websocket_use_shard_gateway and getattr(gateway, "shards", None):
+            shard = (0, int(gateway.shards))
+        await ws.send_json(
+            identify_payload(
+                token=token,
+                intents=self._config.websocket_intents,
+                shard=shard,
+            )
+        )
+
+    async def _heartbeat_loop(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        interval_seconds: float,
+    ) -> None:
+        while True:
+            await asyncio.sleep(interval_seconds)
+            await ws.send_json(heartbeat_payload(self._sequence))
+
+    async def _handle_text_frame(
+        self,
+        ws: aiohttp.ClientWebSocketResponse,
+        text: str,
+    ) -> None:
+        payload = _parse_payload(text)
+        op = payload.get("op")
+        if op == 11:
+            return
+        if op == 7:
+            raise QQWebSocketReconnectRequested()
+        if op == 9:
+            raise QQWebSocketInvalidSession()
+        if op == 1:
+            await ws.send_json(heartbeat_payload(self._sequence))
+            return
+        await self._dispatch_if_needed(payload)
+
+    async def _dispatch_if_needed(self, payload: dict[str, Any]) -> None:
+        if payload.get("s") is not None:
+            try:
+                self._sequence = int(payload["s"])
+            except (TypeError, ValueError):
+                self._sequence = self._sequence
+        if payload.get("op") == 0:
+            event_type = payload.get("t")
+            if event_type == "READY":
+                data = payload.get("d")
+                if isinstance(data, dict):
+                    session_id = data.get("session_id")
+                    if isinstance(session_id, str) and session_id.strip():
+                        self._session_id = session_id.strip()
+            elif event_type == "RESUMED" and self._session_id:
+                logger.info("qq.websocket.resume_succeeded session_id={}", self._session_id)
+        if payload.get("op") == 0:
+            await self._on_payload(payload)
+
+
+def _parse_payload(text: str) -> dict[str, Any]:
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise RuntimeError("qq websocket payload must be a JSON object")
+    return payload
+
+
+class QQWebSocketReconnectRequested(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("qq websocket reconnect requested by server")
+
+
+class QQWebSocketInvalidSession(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("qq websocket invalid session")

--- a/packages/bub-qq/src/bub_qq/websocket.py
+++ b/packages/bub-qq/src/bub_qq/websocket.py
@@ -9,6 +9,7 @@ from typing import Any
 import aiohttp
 from loguru import logger
 
+from .auth import QQAuthError
 from .config import QQConfig
 from .gateway import get_gateway
 from .gateway import get_shard_gateway
@@ -16,6 +17,7 @@ from .gateway import heartbeat_payload
 from .gateway import identify_payload
 from .gateway import resume_payload
 from .openapi import QQOpenAPI
+from .openapi_errors import QQOpenAPIError
 from .ws_errors import QQWebSocketFatalError
 from .ws_errors import raise_for_close_code
 
@@ -81,6 +83,13 @@ class QQWebSocketClient:
                 logger.warning("qq.websocket.invalid_session action=identify_from_scratch")
                 self._session_id = None
                 self._sequence = None
+            except (QQAuthError, QQOpenAPIError) as exc:
+                if _is_permanent_connect_error(exc):
+                    logger.error("qq.websocket.permanent_error error={}", exc)
+                    if self._stop_event is not None:
+                        self._stop_event.set()
+                    break
+                logger.warning("qq.websocket.error error={}", exc)
             except Exception as exc:
                 logger.warning("qq.websocket.error error={}", exc)
             if self._stop_event and self._stop_event.is_set():
@@ -228,3 +237,11 @@ class QQWebSocketReconnectRequested(RuntimeError):
 class QQWebSocketInvalidSession(RuntimeError):
     def __init__(self) -> None:
         super().__init__("qq websocket invalid session")
+
+
+def _is_permanent_connect_error(exc: QQAuthError | QQOpenAPIError) -> bool:
+    if isinstance(exc, QQAuthError):
+        return True
+    if exc.known is not None:
+        return not exc.known.retryable
+    return 400 <= exc.status_code < 500 and exc.status_code != 429

--- a/packages/bub-qq/src/bub_qq/ws_errors.py
+++ b/packages/bub-qq/src/bub_qq/ws_errors.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+RETRYABLE_IDENTIFY_CODES = {4006, 4007, 4008, 4009, *range(4900, 4914)}
+FATAL_WEBSOCKET_CODES = {4001, 4002, 4010, 4011, 4012, 4013, 4014, 4914, 4915}
+
+
+class QQWebSocketFatalError(RuntimeError):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def raise_for_close_code(close_code: int | None) -> None:
+    if close_code is None or close_code < 4000:
+        return
+    if close_code in FATAL_WEBSOCKET_CODES:
+        raise QQWebSocketFatalError(close_code, close_code_message(close_code))
+    if close_code in RETRYABLE_IDENTIFY_CODES:
+        raise RuntimeError(
+            f"qq websocket reconnect required code={close_code} {close_code_message(close_code)}"
+        )
+    raise RuntimeError(f"qq websocket closed code={close_code} {close_code_message(close_code)}")
+
+
+def close_code_message(code: int) -> str:
+    messages = {
+        4001: "invalid opcode",
+        4002: "invalid payload",
+        4006: "invalid session id, identify required",
+        4007: "invalid seq, identify required",
+        4008: "payload sent too fast, reconnect and identify again",
+        4009: "session expired, reconnect and resume or identify",
+        4010: "invalid shard",
+        4011: "too many guilds for this connection",
+        4012: "invalid version",
+        4013: "invalid intent",
+        4014: "intent not permitted",
+        4914: "bot limited to sandbox environment only",
+        4915: "bot is banned",
+    }
+    if 4900 <= code <= 4913:
+        return "internal error, reconnect and identify again"
+    return messages.get(code, "unknown websocket close code")

--- a/packages/bub-qq/src/skills/qq/SKILL.md
+++ b/packages/bub-qq/src/skills/qq/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: qq
+description:
+  QQ C2C channel skill. Use when Bub is handling a QQ conversation and must send a reply
+  explicitly instead of relying on framework auto-delivery.
+metadata:
+  channel: qq
+---
+
+# QQ Skill
+
+Use this skill when the current conversation is on QQ and the framework does not auto-send replies.
+
+## Execution Policy
+
+- QQ currently supports C2C passive replies only.
+- Do not assume a normal text return will be delivered automatically.
+- To reply to the current QQ user, call the packaged send script with:
+  - `openid`: use `sender_id` from the inbound QQ JSON payload
+  - `msg_id`: use `message_id` from the inbound QQ JSON payload
+  - `content`: the final text to send
+- Prefer `msg_seq=1` for a single direct reply to the current inbound message.
+- If `sender_id` or `message_id` is missing, do not attempt to send.
+
+## Context Mapping
+
+Current QQ inbound message JSON typically includes:
+
+- `message`: normalized text content
+- `message_id`: QQ inbound message id for passive reply
+- `sender_id`: QQ user openid
+- `date`
+- `attachments`
+
+## Command Template
+
+Paths are relative to this skill directory.
+
+```bash
+uv run python ./scripts/qq_send.py \
+  --openid <SENDER_ID> \
+  --msg-id <MESSAGE_ID> \
+  --content "<TEXT>" \
+  --msg-seq 1
+```
+
+## Response Contract
+
+- When replying to a QQ user, send the QQ message first using the script above.
+- After the send succeeds, end the turn without restating a conflicting claim such as "QQ skill is unavailable".

--- a/packages/bub-qq/src/skills/qq/SKILL.md
+++ b/packages/bub-qq/src/skills/qq/SKILL.md
@@ -1,26 +1,23 @@
 ---
 name: qq
 description:
-  QQ C2C channel skill. Use when Bub is handling a QQ conversation and must send a reply
-  explicitly instead of relying on framework auto-delivery.
+  QQ C2C channel skill. Use when Bub is handling a QQ conversation. Return your normal text
+  reply directly and let the QQ channel deliver it through standard Bub outbound routing.
 metadata:
   channel: qq
 ---
 
 # QQ Skill
 
-Use this skill when the current conversation is on QQ and the framework does not auto-send replies.
+Use this skill when the current conversation is on QQ.
 
 ## Execution Policy
 
 - QQ currently supports C2C passive replies only.
-- Do not assume a normal text return will be delivered automatically.
-- To reply to the current QQ user, call the packaged send script with:
-  - `openid`: use `sender_id` from the inbound QQ JSON payload
-  - `msg_id`: use `message_id` from the inbound QQ JSON payload
-  - `content`: the final text to send
-- Prefer `msg_seq=1` for a single direct reply to the current inbound message.
-- If `sender_id` or `message_id` is missing, do not attempt to send.
+- For a normal QQ reply, return the final text directly. Bub standard outbound will route it to `QQChannel.send`.
+- Do not call `qq_send.py` for normal replies.
+- Do not construct or pass `msg_seq`; QQ reply sequencing is managed inside the plugin.
+- If the current QQ payload is missing `sender_id` or `message_id`, do not invent protocol fields or shell commands.
 
 ## Context Mapping
 
@@ -32,19 +29,7 @@ Current QQ inbound message JSON typically includes:
 - `date`
 - `attachments`
 
-## Command Template
-
-Paths are relative to this skill directory.
-
-```bash
-uv run python ./scripts/qq_send.py \
-  --openid <SENDER_ID> \
-  --msg-id <MESSAGE_ID> \
-  --content "<TEXT>" \
-  --msg-seq 1
-```
-
 ## Response Contract
 
-- When replying to a QQ user, send the QQ message first using the script above.
-- After the send succeeds, end the turn without restating a conflicting claim such as "QQ skill is unavailable".
+- When replying to a QQ user, return the final reply text and end the turn.
+- Do not describe shell commands, script paths, or `msg_seq` handling in the answer.

--- a/packages/bub-qq/src/skills/qq/__init__.py
+++ b/packages/bub-qq/src/skills/qq/__init__.py
@@ -1,0 +1,1 @@
+"""QQ skill package."""

--- a/packages/bub-qq/src/skills/qq/scripts/qq_send.py
+++ b/packages/bub-qq/src/skills/qq/scripts/qq_send.py
@@ -19,12 +19,11 @@ def main(
     openid: str = typer.Option(..., "--openid", help="QQ user_openid for the current C2C conversation"),
     content: str = typer.Option(..., "--content", help="Reply text to send"),
     msg_id: str = typer.Option(..., "--msg-id", help="Inbound QQ message id to reply to"),
-    msg_seq: int = typer.Option(1, "--msg-seq", help="Reply sequence number for the current inbound message"),
 ) -> None:
-    asyncio.run(_send(openid=openid, content=content, msg_id=msg_id, msg_seq=msg_seq))
+    asyncio.run(_send(openid=openid, content=content, msg_id=msg_id))
 
 
-async def _send(*, openid: str, content: str, msg_id: str, msg_seq: int) -> None:
+async def _send(*, openid: str, content: str, msg_id: str) -> None:
     config = QQConfig()
     if not config.appid or not config.secret:
         raise RuntimeError("qq appid/secret is empty")
@@ -36,7 +35,7 @@ async def _send(*, openid: str, content: str, msg_id: str, msg_seq: int) -> None
             openid=openid,
             content=content,
             msg_id=msg_id,
-            msg_seq=msg_seq,
+            msg_seq=1,
         )
     finally:
         await openapi.aclose()

--- a/packages/bub-qq/src/skills/qq/scripts/qq_send.py
+++ b/packages/bub-qq/src/skills/qq/scripts/qq_send.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import asyncio
+
+import typer
+
+from bub_qq.auth import QQTokenProvider
+from bub_qq.config import QQConfig
+from bub_qq.openapi import QQOpenAPI
+
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def main(
+    openid: str = typer.Option(..., "--openid", help="QQ user_openid for the current C2C conversation"),
+    content: str = typer.Option(..., "--content", help="Reply text to send"),
+    msg_id: str = typer.Option(..., "--msg-id", help="Inbound QQ message id to reply to"),
+    msg_seq: int = typer.Option(1, "--msg-seq", help="Reply sequence number for the current inbound message"),
+) -> None:
+    asyncio.run(_send(openid=openid, content=content, msg_id=msg_id, msg_seq=msg_seq))
+
+
+async def _send(*, openid: str, content: str, msg_id: str, msg_seq: int) -> None:
+    config = QQConfig()
+    if not config.appid or not config.secret:
+        raise RuntimeError("qq appid/secret is empty")
+
+    provider = QQTokenProvider(config)
+    openapi = QQOpenAPI(config, provider)
+    try:
+        result = await openapi.post_c2c_text_message(
+            openid=openid,
+            content=content,
+            msg_id=msg_id,
+            msg_seq=msg_seq,
+        )
+    finally:
+        await openapi.aclose()
+    print(result.get("id", "(no id)"))
+
+
+if __name__ == "__main__":
+    app()

--- a/packages/bub-qq/tests/test_auth.py
+++ b/packages/bub-qq/tests/test_auth.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from bub_qq.auth import QQTokenProvider
+from bub_qq.config import QQConfig
+from bub_qq.openapi import QQOpenAPI
+from bub_qq.openapi_errors import lookup_known_error
+
+
+class Clock:
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_token_provider_caches_until_refresh_boundary() -> None:
+    async def _run() -> None:
+        calls = {"count": 0}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            calls["count"] += 1
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": f"token-{calls['count']}",
+                    "expires_in": 120,
+                },
+            )
+
+        clock = Clock()
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        provider = QQTokenProvider(
+            QQConfig(appid="app", secret="secret", token_refresh_skew_seconds=60),
+            client=client,
+            clock=clock,
+        )
+
+        assert await provider.get_token() == "token-1"
+        assert await provider.get_token() == "token-1"
+
+        clock.now = 59
+        assert await provider.get_token() == "token-1"
+
+        clock.now = 60
+        assert await provider.get_token() == "token-2"
+
+        await client.aclose()
+
+    asyncio.run(_run())
+
+
+def test_openapi_adds_authorization_header() -> None:
+    async def _run() -> None:
+        captured: dict[str, str] = {}
+
+        async def openapi_handler(request: httpx.Request) -> httpx.Response:
+            captured["authorization"] = request.headers["Authorization"]
+            captured["content_type"] = request.headers["Content-Type"]
+            return httpx.Response(200, json={"ok": True})
+
+        async def token_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                json={"access_token": "abc", "expires_in": 7200},
+            )
+
+        openapi_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(openapi_handler),
+            base_url="https://api.sgroup.qq.com",
+        )
+        token_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(token_handler),
+        )
+        provider = QQTokenProvider(
+            QQConfig(appid="app", secret="secret"),
+            client=token_client,
+        )
+        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+
+        payload = await openapi.post("/test", json_body={"ping": "pong"})
+
+        assert payload == {"ok": True}
+        assert captured["authorization"] == "QQBot abc"
+        assert captured["content_type"] == "application/json"
+
+        await openapi_client.aclose()
+        await token_client.aclose()
+
+    asyncio.run(_run())
+
+
+def test_openapi_posts_c2c_text_message() -> None:
+    async def _run() -> None:
+        captured: dict[str, object] = {}
+
+        async def openapi_handler(request: httpx.Request) -> httpx.Response:
+            captured["path"] = request.url.path
+            captured["json"] = await request.aread()
+            return httpx.Response(200, json={"id": "reply-1", "timestamp": 123})
+
+        async def token_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                json={"access_token": "abc", "expires_in": 7200},
+            )
+
+        openapi_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(openapi_handler),
+            base_url="https://api.sgroup.qq.com",
+        )
+        token_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(token_handler),
+        )
+        provider = QQTokenProvider(
+            QQConfig(appid="app", secret="secret"),
+            client=token_client,
+        )
+        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+
+        payload = await openapi.post_c2c_text_message(
+            openid="user-openid",
+            content="hello",
+            msg_id="message-1",
+            msg_seq=2,
+        )
+
+        assert payload["id"] == "reply-1"
+        assert captured["path"] == "/v2/users/user-openid/messages"
+        assert captured["json"] == b'{"content":"hello","msg_type":0,"msg_id":"message-1","msg_seq":2}'
+
+        await openapi_client.aclose()
+        await token_client.aclose()
+
+    asyncio.run(_run())
+
+
+def test_openapi_error_exposes_trace_id_and_business_code() -> None:
+    async def _run() -> None:
+        async def openapi_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                429,
+                headers={"X-Tps-trace-ID": "trace-123"},
+                json={"code": 22009, "message": "msg limit exceed"},
+            )
+
+        async def token_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                json={"access_token": "abc", "expires_in": 7200},
+            )
+
+        openapi_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(openapi_handler),
+            base_url="https://api.sgroup.qq.com",
+        )
+        token_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(token_handler),
+        )
+        provider = QQTokenProvider(
+            QQConfig(appid="app", secret="secret"),
+            client=token_client,
+        )
+        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+
+        try:
+            await openapi.post("/test", json_body={"ping": "pong"})
+        except Exception as exc:
+            assert "trace_id=trace-123" in str(exc)
+            assert "code=22009" in str(exc)
+            assert "category=rate_limit" in str(exc)
+            assert "msg limit exceed" in str(exc)
+        else:
+            raise AssertionError("expected openapi request to fail")
+
+        await openapi_client.aclose()
+        await token_client.aclose()
+
+    asyncio.run(_run())
+
+
+def test_known_openapi_error_catalog_contains_reply_expired() -> None:
+    known = lookup_known_error(304027)
+
+    assert known is not None
+    assert known.name == "MSG_EXPIRE"
+    assert known.category == "reply"
+    assert known.retryable is False

--- a/packages/bub-qq/tests/test_auth.py
+++ b/packages/bub-qq/tests/test_auth.py
@@ -119,7 +119,12 @@ def test_token_provider_caches_until_refresh_boundary() -> None:
 
         clock = Clock()
         provider = QQTokenProvider(
-            QQConfig(appid="app", secret="secret", token_refresh_skew_seconds=60),
+            QQConfig(
+                appid="app",
+                secret="secret",
+                receive_mode="webhook",
+                token_refresh_skew_seconds=60,
+            ),
             client=FakeTokenClient(handler),
             clock=clock,
         )
@@ -153,10 +158,14 @@ def test_openapi_adds_authorization_header() -> None:
             )
 
         provider = QQTokenProvider(
-            QQConfig(appid="app", secret="secret"),
+            QQConfig(appid="app", secret="secret", receive_mode="webhook"),
             client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
+        openapi = QQOpenAPI(
+            QQConfig(receive_mode="webhook"),
+            provider,
+            client=FakeOpenAPIClient(openapi_handler),
+        )
 
         payload = await openapi.post("/test", json_body={"ping": "pong"})
 
@@ -184,10 +193,14 @@ def test_openapi_posts_c2c_text_message() -> None:
             )
 
         provider = QQTokenProvider(
-            QQConfig(appid="app", secret="secret"),
+            QQConfig(appid="app", secret="secret", receive_mode="webhook"),
             client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
+        openapi = QQOpenAPI(
+            QQConfig(receive_mode="webhook"),
+            provider,
+            client=FakeOpenAPIClient(openapi_handler),
+        )
 
         payload = await openapi.post_c2c_text_message(
             openid="user-openid",
@@ -227,10 +240,14 @@ def test_openapi_error_exposes_trace_id_and_business_code() -> None:
             )
 
         provider = QQTokenProvider(
-            QQConfig(appid="app", secret="secret"),
+            QQConfig(appid="app", secret="secret", receive_mode="webhook"),
             client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
+        openapi = QQOpenAPI(
+            QQConfig(receive_mode="webhook"),
+            provider,
+            client=FakeOpenAPIClient(openapi_handler),
+        )
 
         try:
             await openapi.post("/test", json_body={"ping": "pong"})

--- a/packages/bub-qq/tests/test_auth.py
+++ b/packages/bub-qq/tests/test_auth.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-
-import httpx
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Any
+from typing import Protocol
 
 from bub_qq.auth import QQTokenProvider
 from bub_qq.config import QQConfig
@@ -18,26 +20,107 @@ class Clock:
         return self.now
 
 
+class FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        payload: Any = None,
+        headers: dict[str, str] | None = None,
+        reason: str = "OK",
+    ) -> None:
+        self.status = status
+        self.payload = payload
+        self.headers = headers or {}
+        self.reason = reason
+
+
+class OpenAPIRequest(Protocol):
+    method: str
+    url: str
+    params: dict[str, object] | None
+    json: dict[str, object] | None
+    headers: dict[str, str]
+
+
+class _OpenAPIRequest:
+    def __init__(
+        self,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, object] | None,
+        json: dict[str, object] | None,
+        headers: dict[str, str],
+    ) -> None:
+        self.method = method
+        self.url = url
+        self.params = params
+        self.json = json
+        self.headers = headers
+
+
+class FakeTokenClient:
+    def __init__(
+        self,
+        handler: Callable[[str, dict[str, object]], Awaitable[FakeResponse]],
+    ) -> None:
+        self._handler = handler
+
+    async def post(self, url: str, **kwargs: object) -> dict[str, object]:
+        response = await self._handler(url, kwargs)
+        if response.status < 200 or response.status >= 300:
+            raise RuntimeError(
+                f"qq token request failed: http={response.status} reason={response.reason}"
+            )
+        if not isinstance(response.payload, dict):
+            raise RuntimeError(f"qq token response is not a JSON object: {response.payload!r}")
+        return response.payload
+
+
+class FakeOpenAPIClient:
+    def __init__(self, handler: Callable[[OpenAPIRequest], Awaitable[FakeResponse]]) -> None:
+        self._handler = handler
+
+    async def request(
+        self,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, object] | None,
+        json: dict[str, object] | None,
+        headers: dict[str, str],
+    ) -> FakeResponse:
+        return await self._handler(
+            _OpenAPIRequest(
+                method=method,
+                url=url,
+                params=params,
+                json=json,
+                headers=headers,
+            )
+        )
+
+
 def test_token_provider_caches_until_refresh_boundary() -> None:
     async def _run() -> None:
         calls = {"count": 0}
 
-        async def handler(request: httpx.Request) -> httpx.Response:
-            del request
+        async def handler(url: str, kwargs: dict[str, object]) -> FakeResponse:
+            del url, kwargs
             calls["count"] += 1
-            return httpx.Response(
-                200,
-                json={
+            return FakeResponse(
+                status=200,
+                payload={
                     "access_token": f"token-{calls['count']}",
                     "expires_in": 120,
                 },
             )
 
         clock = Clock()
-        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         provider = QQTokenProvider(
             QQConfig(appid="app", secret="secret", token_refresh_skew_seconds=60),
-            client=client,
+            client=FakeTokenClient(handler),
             clock=clock,
         )
 
@@ -50,8 +133,6 @@ def test_token_provider_caches_until_refresh_boundary() -> None:
         clock.now = 60
         assert await provider.get_token() == "token-2"
 
-        await client.aclose()
-
     asyncio.run(_run())
 
 
@@ -59,39 +140,29 @@ def test_openapi_adds_authorization_header() -> None:
     async def _run() -> None:
         captured: dict[str, str] = {}
 
-        async def openapi_handler(request: httpx.Request) -> httpx.Response:
+        async def openapi_handler(request: OpenAPIRequest) -> FakeResponse:
             captured["authorization"] = request.headers["Authorization"]
             captured["content_type"] = request.headers["Content-Type"]
-            return httpx.Response(200, json={"ok": True})
+            return FakeResponse(status=200, payload={"ok": True})
 
-        async def token_handler(request: httpx.Request) -> httpx.Response:
-            del request
-            return httpx.Response(
-                200,
-                json={"access_token": "abc", "expires_in": 7200},
+        async def token_handler(url: str, kwargs: dict[str, object]) -> FakeResponse:
+            del url, kwargs
+            return FakeResponse(
+                status=200,
+                payload={"access_token": "abc", "expires_in": 7200},
             )
 
-        openapi_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(openapi_handler),
-            base_url="https://api.sgroup.qq.com",
-        )
-        token_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(token_handler),
-        )
         provider = QQTokenProvider(
             QQConfig(appid="app", secret="secret"),
-            client=token_client,
+            client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
 
         payload = await openapi.post("/test", json_body={"ping": "pong"})
 
         assert payload == {"ok": True}
         assert captured["authorization"] == "QQBot abc"
         assert captured["content_type"] == "application/json"
-
-        await openapi_client.aclose()
-        await token_client.aclose()
 
     asyncio.run(_run())
 
@@ -100,30 +171,23 @@ def test_openapi_posts_c2c_text_message() -> None:
     async def _run() -> None:
         captured: dict[str, object] = {}
 
-        async def openapi_handler(request: httpx.Request) -> httpx.Response:
-            captured["path"] = request.url.path
-            captured["json"] = await request.aread()
-            return httpx.Response(200, json={"id": "reply-1", "timestamp": 123})
+        async def openapi_handler(request: OpenAPIRequest) -> FakeResponse:
+            captured["path"] = request.url
+            captured["json"] = request.json
+            return FakeResponse(status=200, payload={"id": "reply-1", "timestamp": 123})
 
-        async def token_handler(request: httpx.Request) -> httpx.Response:
-            del request
-            return httpx.Response(
-                200,
-                json={"access_token": "abc", "expires_in": 7200},
+        async def token_handler(url: str, kwargs: dict[str, object]) -> FakeResponse:
+            del url, kwargs
+            return FakeResponse(
+                status=200,
+                payload={"access_token": "abc", "expires_in": 7200},
             )
 
-        openapi_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(openapi_handler),
-            base_url="https://api.sgroup.qq.com",
-        )
-        token_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(token_handler),
-        )
         provider = QQTokenProvider(
             QQConfig(appid="app", secret="secret"),
-            client=token_client,
+            client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
 
         payload = await openapi.post_c2c_text_message(
             openid="user-openid",
@@ -134,43 +198,39 @@ def test_openapi_posts_c2c_text_message() -> None:
 
         assert payload["id"] == "reply-1"
         assert captured["path"] == "/v2/users/user-openid/messages"
-        assert captured["json"] == b'{"content":"hello","msg_type":0,"msg_id":"message-1","msg_seq":2}'
-
-        await openapi_client.aclose()
-        await token_client.aclose()
+        assert captured["json"] == {
+            "content": "hello",
+            "msg_type": 0,
+            "msg_id": "message-1",
+            "msg_seq": 2,
+        }
 
     asyncio.run(_run())
 
 
 def test_openapi_error_exposes_trace_id_and_business_code() -> None:
     async def _run() -> None:
-        async def openapi_handler(request: httpx.Request) -> httpx.Response:
+        async def openapi_handler(request: OpenAPIRequest) -> FakeResponse:
             del request
-            return httpx.Response(
-                429,
+            return FakeResponse(
+                status=429,
                 headers={"X-Tps-trace-ID": "trace-123"},
-                json={"code": 22009, "message": "msg limit exceed"},
+                payload={"code": 22009, "message": "msg limit exceed"},
+                reason="Too Many Requests",
             )
 
-        async def token_handler(request: httpx.Request) -> httpx.Response:
-            del request
-            return httpx.Response(
-                200,
-                json={"access_token": "abc", "expires_in": 7200},
+        async def token_handler(url: str, kwargs: dict[str, object]) -> FakeResponse:
+            del url, kwargs
+            return FakeResponse(
+                status=200,
+                payload={"access_token": "abc", "expires_in": 7200},
             )
 
-        openapi_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(openapi_handler),
-            base_url="https://api.sgroup.qq.com",
-        )
-        token_client = httpx.AsyncClient(
-            transport=httpx.MockTransport(token_handler),
-        )
         provider = QQTokenProvider(
             QQConfig(appid="app", secret="secret"),
-            client=token_client,
+            client=FakeTokenClient(token_handler),
         )
-        openapi = QQOpenAPI(QQConfig(), provider, client=openapi_client)
+        openapi = QQOpenAPI(QQConfig(), provider, client=FakeOpenAPIClient(openapi_handler))
 
         try:
             await openapi.post("/test", json_body={"ping": "pong"})
@@ -181,9 +241,6 @@ def test_openapi_error_exposes_trace_id_and_business_code() -> None:
             assert "msg limit exceed" in str(exc)
         else:
             raise AssertionError("expected openapi request to fail")
-
-        await openapi_client.aclose()
-        await token_client.aclose()
 
     asyncio.run(_run())
 

--- a/packages/bub-qq/tests/test_c2c_services.py
+++ b/packages/bub-qq/tests/test_c2c_services.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import asyncio
+
+from bub.channels.message import ChannelMessage
+
+from bub_qq.c2c import QQC2CDeduper
+from bub_qq.c2c import QQC2CInboundService
+from bub_qq.c2c import QQC2CSendService
+from bub_qq.c2c import QQC2CSessionState
+from bub_qq.openapi_errors import QQKnownOpenAPIError
+from bub_qq.openapi_errors import QQOpenAPIError
+
+
+class OpenAPIStub:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "openid": openid,
+                "content": content,
+                "msg_id": msg_id,
+                "msg_seq": msg_seq,
+            }
+        )
+        return {"id": "reply-1"}
+
+
+class FailingOpenAPIStub:
+    def __init__(self, error: QQOpenAPIError) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, object]:
+        del openid, content, msg_id, msg_seq
+        self.calls += 1
+        raise self.error
+
+
+def _state() -> QQC2CSessionState:
+    return QQC2CSessionState(
+        latest_message_id_by_session={},
+        latest_sequence_by_session={},
+        latest_timestamp_by_session={},
+        send_record_by_session_and_msg_id={},
+    )
+
+
+def _payload(message_id: str = "message-1") -> dict[str, object]:
+    return {
+        "id": "event-1",
+        "op": 0,
+        "s": 42,
+        "t": "C2C_MESSAGE_CREATE",
+        "d": {
+            "author": {"user_openid": "user-openid"},
+            "content": "hello",
+            "id": message_id,
+            "timestamp": "2099-01-01T00:00:00+00:00",
+        },
+    }
+
+
+def test_c2c_inbound_service_parses_and_remembers_session() -> None:
+    state = _state()
+    service = QQC2CInboundService(channel_name="qq", deduper=QQC2CDeduper(16), state=state)
+
+    parsed = service.parse_inbound(_payload())
+
+    assert parsed is not None
+    message, channel_message = parsed
+    assert message.message_id == "message-1"
+    assert channel_message.session_id == "qq:c2c:user-openid"
+    assert state.latest_message_id_by_session["qq:c2c:user-openid"] == "message-1"
+    assert state.latest_sequence_by_session == {}
+
+
+def test_c2c_inbound_service_dedupes_repeated_messages() -> None:
+    state = _state()
+    service = QQC2CInboundService(channel_name="qq", deduper=QQC2CDeduper(16), state=state)
+
+    assert service.parse_inbound(_payload("message-1")) is not None
+    assert service.parse_inbound(_payload("message-1")) is None
+
+
+def test_c2c_send_service_sends_using_session_context() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        result = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert result == {"id": "reply-1"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "hello",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_starts_msg_seq_at_one_after_inbound_transport_sequence() -> None:
+    async def _run() -> None:
+        state = _state()
+        inbound = QQC2CInboundService(channel_name="qq", deduper=QQC2CDeduper(16), state=state)
+        parsed = inbound.parse_inbound(_payload())
+
+        assert parsed is not None
+
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        result = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert result == {"id": "reply-1"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "hello",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+        assert state.latest_sequence_by_session["qq:c2c:user-openid"] == 1
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_strips_qq_wrapper_prefix_before_sending() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        result = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="$qq → \n你好呀！",
+                channel="qq",
+            )
+        )
+
+        assert result == {"id": "reply-1"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "你好呀！",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_returns_already_sent_for_same_content() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        first = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+        second = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert first == {"id": "reply-1"}
+        assert second == {"id": "reply-1", "status": "already_sent"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "hello",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_rejects_duplicate_reply_with_different_content() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        first = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+        second = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="different reply",
+                channel="qq",
+            )
+        )
+
+        assert first == {"id": "reply-1"}
+        assert second == {"status": "duplicate_reply_blocked"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "hello",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_skips_when_passive_reply_window_expired() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2000-01-01T00:00:00+00:00"
+        openapi = OpenAPIStub()
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        result = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert result is None
+        assert openapi.calls == []
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_swallows_openapi_errors() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = FailingOpenAPIStub(
+            QQOpenAPIError(
+                status_code=429,
+                trace_id="trace-1",
+                error_code=22009,
+                error_message="msg limit exceed",
+                known=QQKnownOpenAPIError(22009, "MsgLimitExceed", "消息发送超频", "rate_limit", True),
+            )
+        )
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        result = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert result is None
+        assert openapi.calls == 1
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_treats_remote_duplicate_as_already_sent() -> None:
+    async def _run() -> None:
+        state = _state()
+        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+        openapi = FailingOpenAPIStub(
+            QQOpenAPIError(
+                status_code=400,
+                trace_id="trace-duplicate",
+                error_code=40054005,
+                error_message="消息被去重，请检查请求msgseq",
+                known=QQKnownOpenAPIError(
+                    40054005,
+                    "MessageDeduplicated",
+                    "消息被去重，请检查请求 msgseq",
+                    "reply",
+                    False,
+                ),
+            )
+        )
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        first = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+        second = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="hello",
+                channel="qq",
+            )
+        )
+
+        assert first == {"status": "already_sent"}
+        assert second == {"status": "already_sent"}
+        assert openapi.calls == 1
+
+    asyncio.run(_run())

--- a/packages/bub-qq/tests/test_channel.py
+++ b/packages/bub-qq/tests/test_channel.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+
+from bub.channels.message import ChannelMessage
+
+from bub_qq.channel import QQChannel
+from bub_qq.c2c import build_c2c_channel_message
+from bub_qq.models import QQC2CMessage
+from bub_qq.openapi_errors import QQKnownOpenAPIError
+from bub_qq.openapi_errors import QQOpenAPIError
+
+
+class OpenAPIStub:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "openid": openid,
+                "content": content,
+                "msg_id": msg_id,
+                "msg_seq": msg_seq,
+            }
+        )
+        return {"id": "reply-1", "timestamp": 123}
+
+    async def aclose(self) -> None:
+        return None
+
+
+class FailingOpenAPIStub:
+    def __init__(self, error: QQOpenAPIError) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def post_c2c_text_message(
+        self,
+        *,
+        openid: str,
+        content: str,
+        msg_id: str,
+        msg_seq: int,
+    ) -> dict[str, object]:
+        del openid, content, msg_id, msg_seq
+        self.calls += 1
+        raise self.error
+
+    async def aclose(self) -> None:
+        return None
+
+
+def test_channel_send_uses_latest_c2c_message_context() -> None:
+    async def _run() -> None:
+        channel = QQChannel(lambda message: None)
+        channel._openapi = OpenAPIStub()  # type: ignore[assignment]
+        channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+
+        await channel.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                content="hello",
+                channel="qq",
+                chat_id="c2c:user-openid",
+            )
+        )
+
+        assert channel._openapi.calls == [  # type: ignore[attr-defined]
+            {
+                "openid": "user-openid",
+                "content": "hello",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_channel_send_handles_reply_expired_error() -> None:
+    async def _run() -> None:
+        channel = QQChannel(lambda message: None)
+        channel._openapi = FailingOpenAPIStub(  # type: ignore[assignment]
+            QQOpenAPIError(
+                status_code=400,
+                trace_id="trace-1",
+                error_code=304027,
+                error_message="reply expired",
+                known=QQKnownOpenAPIError(304027, "MSG_EXPIRE", "回复的消息过期", "reply", False),
+            )
+        )
+        channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+
+        await channel.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                content="hello",
+                channel="qq",
+                chat_id="c2c:user-openid",
+            )
+        )
+
+        assert channel._openapi.calls == 1  # type: ignore[attr-defined]
+
+    asyncio.run(_run())
+
+
+def test_channel_send_handles_rate_limit_error() -> None:
+    async def _run() -> None:
+        channel = QQChannel(lambda message: None)
+        channel._openapi = FailingOpenAPIStub(  # type: ignore[assignment]
+            QQOpenAPIError(
+                status_code=429,
+                trace_id="trace-2",
+                error_code=22009,
+                error_message="msg limit exceed",
+                known=QQKnownOpenAPIError(22009, "MsgLimitExceed", "消息发送超频", "rate_limit", True),
+            )
+        )
+        channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
+        channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
+
+        await channel.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                content="hello",
+                channel="qq",
+                chat_id="c2c:user-openid",
+            )
+        )
+
+        assert channel._openapi.calls == 1  # type: ignore[attr-defined]
+
+    asyncio.run(_run())
+
+
+def test_c2c_inbound_defaults_outbound_to_qq_channel() -> None:
+    message = QQC2CMessage(
+        message_id="message-1",
+        event_id="event-1",
+        user_openid="user-openid",
+        content="hello",
+        timestamp="2026-03-19T00:00:00+00:00",
+        attachments=(),
+        sequence=1,
+    )
+
+    channel_message = build_c2c_channel_message("qq", message)
+
+    assert channel_message.output_channel == "null"

--- a/packages/bub-qq/tests/test_channel.py
+++ b/packages/bub-qq/tests/test_channel.py
@@ -6,6 +6,7 @@ from bub.channels.message import ChannelMessage
 
 from bub_qq.channel import QQChannel
 from bub_qq.c2c import build_c2c_channel_message
+from bub_qq.c2c import QQC2CSendService
 from bub_qq.models import QQC2CMessage
 from bub_qq.openapi_errors import QQKnownOpenAPIError
 from bub_qq.openapi_errors import QQOpenAPIError
@@ -58,10 +59,20 @@ class FailingOpenAPIStub:
         return None
 
 
+def _install_send_service(channel: QQChannel, openapi: object) -> None:
+    channel._c2c_send = QQC2CSendService(  # type: ignore[assignment]
+        channel_name=channel.name,
+        receive_mode=channel._config.receive_mode,
+        state=channel._c2c_state,
+        openapi=openapi,  # type: ignore[arg-type]
+    )
+
+
 def test_channel_send_uses_latest_c2c_message_context() -> None:
     async def _run() -> None:
         channel = QQChannel(lambda message: None)
-        channel._openapi = OpenAPIStub()  # type: ignore[assignment]
+        openapi = OpenAPIStub()
+        _install_send_service(channel, openapi)
         channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
         channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
 
@@ -74,7 +85,7 @@ def test_channel_send_uses_latest_c2c_message_context() -> None:
             )
         )
 
-        assert channel._openapi.calls == [  # type: ignore[attr-defined]
+        assert openapi.calls == [
             {
                 "openid": "user-openid",
                 "content": "hello",
@@ -89,7 +100,7 @@ def test_channel_send_uses_latest_c2c_message_context() -> None:
 def test_channel_send_handles_reply_expired_error() -> None:
     async def _run() -> None:
         channel = QQChannel(lambda message: None)
-        channel._openapi = FailingOpenAPIStub(  # type: ignore[assignment]
+        openapi = FailingOpenAPIStub(
             QQOpenAPIError(
                 status_code=400,
                 trace_id="trace-1",
@@ -98,6 +109,7 @@ def test_channel_send_handles_reply_expired_error() -> None:
                 known=QQKnownOpenAPIError(304027, "MSG_EXPIRE", "回复的消息过期", "reply", False),
             )
         )
+        _install_send_service(channel, openapi)
         channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
         channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
 
@@ -110,7 +122,7 @@ def test_channel_send_handles_reply_expired_error() -> None:
             )
         )
 
-        assert channel._openapi.calls == 1  # type: ignore[attr-defined]
+        assert openapi.calls == 1
 
     asyncio.run(_run())
 
@@ -118,7 +130,7 @@ def test_channel_send_handles_reply_expired_error() -> None:
 def test_channel_send_handles_rate_limit_error() -> None:
     async def _run() -> None:
         channel = QQChannel(lambda message: None)
-        channel._openapi = FailingOpenAPIStub(  # type: ignore[assignment]
+        openapi = FailingOpenAPIStub(
             QQOpenAPIError(
                 status_code=429,
                 trace_id="trace-2",
@@ -127,6 +139,7 @@ def test_channel_send_handles_rate_limit_error() -> None:
                 known=QQKnownOpenAPIError(22009, "MsgLimitExceed", "消息发送超频", "rate_limit", True),
             )
         )
+        _install_send_service(channel, openapi)
         channel._c2c_state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
         channel._c2c_state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
 
@@ -139,7 +152,7 @@ def test_channel_send_handles_rate_limit_error() -> None:
             )
         )
 
-        assert channel._openapi.calls == 1  # type: ignore[attr-defined]
+        assert openapi.calls == 1
 
     asyncio.run(_run())
 
@@ -157,4 +170,4 @@ def test_c2c_inbound_defaults_outbound_to_qq_channel() -> None:
 
     channel_message = build_c2c_channel_message("qq", message)
 
-    assert channel_message.output_channel == "null"
+    assert channel_message.output_channel != "null"

--- a/packages/bub-qq/tests/test_config.py
+++ b/packages/bub-qq/tests/test_config.py
@@ -7,8 +7,23 @@ from bub_qq.config import QQConfig
 
 def test_inbound_dedupe_size_must_be_positive() -> None:
     try:
-        QQConfig(inbound_dedupe_size=0)
+        QQConfig(receive_mode="webhook", inbound_dedupe_size=0)
     except ValidationError as exc:
         assert "inbound_dedupe_size" in str(exc)
     else:
         raise AssertionError("expected inbound_dedupe_size=0 to be rejected")
+
+
+def test_receive_mode_is_required() -> None:
+    try:
+        QQConfig()
+    except ValidationError as exc:
+        assert "receive_mode" in str(exc)
+    else:
+        raise AssertionError("expected missing receive_mode to be rejected")
+
+
+def test_webhook_port_defaults_to_official_allowed_port() -> None:
+    config = QQConfig(receive_mode="webhook")
+
+    assert config.webhook_port == 8080

--- a/packages/bub-qq/tests/test_config.py
+++ b/packages/bub-qq/tests/test_config.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from bub_qq.config import QQConfig
+
+
+def test_inbound_dedupe_size_must_be_positive() -> None:
+    try:
+        QQConfig(inbound_dedupe_size=0)
+    except ValidationError as exc:
+        assert "inbound_dedupe_size" in str(exc)
+    else:
+        raise AssertionError("expected inbound_dedupe_size=0 to be rejected")

--- a/packages/bub-qq/tests/test_gateway.py
+++ b/packages/bub-qq/tests/test_gateway.py
@@ -1,14 +1,100 @@
 from __future__ import annotations
 
+import asyncio
+
 from bub_qq.auth import QQAuthError
+from bub_qq.gateway import get_gateway
+from bub_qq.gateway import get_shard_gateway
 from bub_qq.gateway import heartbeat_payload
 from bub_qq.gateway import identify_payload
 from bub_qq.gateway import resume_payload
+from bub_qq.openapi import QQOpenAPI
 from bub_qq.openapi_errors import QQKnownOpenAPIError
 from bub_qq.openapi_errors import QQOpenAPIError
 from bub_qq.websocket import _is_permanent_connect_error
 from bub_qq.ws_errors import QQWebSocketFatalError
 from bub_qq.ws_errors import raise_for_close_code
+
+
+class TokenProviderStub:
+    async def get_token(self) -> str:
+        return "token"
+
+
+class OpenAPIClientStub:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+
+    async def request(
+        self,
+        *,
+        method: str,
+        url: str,
+        params: dict[str, object] | None,
+        json: dict[str, object] | None,
+        headers: dict[str, str],
+    ) -> object:
+        del method, params, json, headers
+        return _Response(status=200, payload=self.payload if url.startswith("/gateway") else {})
+
+
+class _Response:
+    def __init__(self, *, status: int, payload: object) -> None:
+        self.status = status
+        self.payload = payload
+        self.headers: dict[str, str] = {}
+        self.reason = "OK"
+
+
+def test_get_gateway_returns_url() -> None:
+    async def _run() -> None:
+        openapi = QQOpenAPI(
+            config=_ConfigStub(),
+            token_provider=TokenProviderStub(),
+            client=OpenAPIClientStub({"url": "wss://api.sgroup.qq.com/websocket/"}),
+        )
+
+        gateway = await get_gateway(openapi)
+
+        assert gateway.url == "wss://api.sgroup.qq.com/websocket/"
+        assert gateway.shards is None
+        assert gateway.session_start_limit is None
+        assert gateway.max_concurrency is None
+
+    asyncio.run(_run())
+
+
+def test_get_shard_gateway_returns_full_session_start_limit() -> None:
+    async def _run() -> None:
+        openapi = QQOpenAPI(
+            config=_ConfigStub(),
+            token_provider=TokenProviderStub(),
+            client=OpenAPIClientStub(
+                {
+                    "url": "wss://api.sgroup.qq.com/websocket/",
+                    "shards": 9,
+                    "session_start_limit": {
+                        "total": 1000,
+                        "remaining": 999,
+                        "reset_after": 14400000,
+                        "max_concurrency": 1,
+                    },
+                }
+            ),
+        )
+
+        gateway = await get_shard_gateway(openapi)
+
+        assert gateway.url == "wss://api.sgroup.qq.com/websocket/"
+        assert gateway.shards == 9
+        assert gateway.session_start_limit is not None
+        assert gateway.session_start_limit.total == 1000
+        assert gateway.session_start_limit.remaining == 999
+        assert gateway.session_start_limit.reset_after == 14400000
+        assert gateway.session_start_limit.max_concurrency == 1
+        assert gateway.max_concurrency == 1
+
+    asyncio.run(_run())
 
 
 def test_identify_payload_uses_qqbot_token_and_intents() -> None:
@@ -73,3 +159,8 @@ def test_websocket_retryable_openapi_errors_are_not_treated_as_permanent() -> No
     )
 
     assert _is_permanent_connect_error(error) is False
+
+
+class _ConfigStub:
+    timeout_seconds = 5.0
+    openapi_base_url = "https://api.sgroup.qq.com"

--- a/packages/bub-qq/tests/test_gateway.py
+++ b/packages/bub-qq/tests/test_gateway.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from bub_qq.gateway import heartbeat_payload
+from bub_qq.gateway import identify_payload
+from bub_qq.gateway import resume_payload
+from bub_qq.ws_errors import QQWebSocketFatalError
+from bub_qq.ws_errors import raise_for_close_code
+
+
+def test_identify_payload_uses_qqbot_token_and_intents() -> None:
+    payload = identify_payload(token="abc", intents=1 << 25, shard=(0, 1))
+
+    assert payload["op"] == 2
+    assert payload["d"]["token"] == "QQBot abc"
+    assert payload["d"]["intents"] == 1 << 25
+    assert payload["d"]["shard"] == [0, 1]
+
+
+def test_heartbeat_payload_uses_latest_sequence() -> None:
+    assert heartbeat_payload(42) == {"op": 1, "d": 42}
+
+
+def test_resume_payload_uses_session_and_sequence() -> None:
+    payload = resume_payload(token="abc", session_id="session-1", sequence=42)
+
+    assert payload == {
+        "op": 6,
+        "d": {
+            "token": "QQBot abc",
+            "session_id": "session-1",
+            "seq": 42,
+        },
+    }
+
+
+def test_websocket_fatal_close_code_stops_reconnect() -> None:
+    try:
+        raise_for_close_code(4915)
+    except QQWebSocketFatalError as exc:
+        assert exc.code == 4915
+        assert "banned" in str(exc)
+    else:
+        raise AssertionError("expected fatal websocket close code")

--- a/packages/bub-qq/tests/test_gateway.py
+++ b/packages/bub-qq/tests/test_gateway.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from bub_qq.auth import QQAuthError
 from bub_qq.gateway import heartbeat_payload
 from bub_qq.gateway import identify_payload
 from bub_qq.gateway import resume_payload
+from bub_qq.openapi_errors import QQKnownOpenAPIError
+from bub_qq.openapi_errors import QQOpenAPIError
+from bub_qq.websocket import _is_permanent_connect_error
 from bub_qq.ws_errors import QQWebSocketFatalError
 from bub_qq.ws_errors import raise_for_close_code
 
@@ -41,3 +45,31 @@ def test_websocket_fatal_close_code_stops_reconnect() -> None:
         assert "banned" in str(exc)
     else:
         raise AssertionError("expected fatal websocket close code")
+
+
+def test_websocket_auth_errors_are_treated_as_permanent() -> None:
+    assert _is_permanent_connect_error(QQAuthError("bad credentials")) is True
+
+
+def test_websocket_non_retryable_openapi_errors_are_treated_as_permanent() -> None:
+    error = QQOpenAPIError(
+        status_code=403,
+        trace_id="trace-1",
+        error_code=11253,
+        error_message="permission denied",
+        known=QQKnownOpenAPIError(11253, "ErrorCheckAppPrivilegeNotPass", "应用未获得调用接口权限", "permission", False),
+    )
+
+    assert _is_permanent_connect_error(error) is True
+
+
+def test_websocket_retryable_openapi_errors_are_not_treated_as_permanent() -> None:
+    error = QQOpenAPIError(
+        status_code=429,
+        trace_id="trace-2",
+        error_code=22009,
+        error_message="msg limit exceed",
+        known=QQKnownOpenAPIError(22009, "MsgLimitExceed", "消息发送超频", "rate_limit", True),
+    )
+
+    assert _is_permanent_connect_error(error) is False

--- a/packages/bub-qq/tests/test_models.py
+++ b/packages/bub-qq/tests/test_models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from bub_qq.models import QQC2CMessage
+
+
+def test_c2c_message_parses_minimal_payload() -> None:
+    message = QQC2CMessage.from_event(
+        {
+            "id": "event-1",
+            "op": 0,
+            "s": 42,
+            "t": "C2C_MESSAGE_CREATE",
+            "d": {
+                "author": {"user_openid": "user-openid"},
+                "content": "123",
+                "id": "message-1",
+                "timestamp": "2023-11-06T13:37:18+08:00",
+            },
+        }
+    )
+
+    assert message.event_id == "event-1"
+    assert message.sequence == 42
+    assert message.user_openid == "user-openid"
+    assert message.message_id == "message-1"
+    assert message.content == "123"
+    assert message.timestamp == "2023-11-06T13:37:18+08:00"
+    assert message.attachments == ()

--- a/packages/bub-qq/tests/test_signature.py
+++ b/packages/bub-qq/tests/test_signature.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from bub_qq.signature import sign_validation_payload
+from bub_qq.signature import verify_request_signature
+
+
+def test_validation_signature_matches_official_example() -> None:
+    signature = sign_validation_payload(
+        secret="DG5g3B4j9X2KOErG",
+        event_ts="1725442341",
+        plain_token="Arq0D5A61EgUu4OxUvOp",
+    )
+
+    assert (
+        signature
+        == "87befc99c42c651b3aac0278e71ada338433ae26fcb24307bdc5ad38c1adc2d01bcfcadc0842edac85e85205028a1132afe09280305f13aa6909ffc2d652c706"
+    )
+
+
+def test_request_signature_matches_official_example() -> None:
+    assert verify_request_signature(
+        secret="naOC0ocQE3shWLAfffVLB1rhYPG7",
+        timestamp="1725442341",
+        body=b'{ "op": 0,"d": {}, "t": "GATEWAY_EVENT_NAME"}',
+        signature_hex="865ad13a61752ca65e26bde6676459cd36cf1be609375b37bd62af366e1dc25a8dc789ba7f14e017ada3d554c671a911bfdf075ba54835b23391d509579ed002",
+    )

--- a/packages/bub-qq/tests/test_skill_contract.py
+++ b/packages/bub-qq/tests/test_skill_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_qq_skill_returns_text_instead_of_script_send() -> None:
+    skill = (
+        Path(__file__)
+        .resolve()
+        .parents[1]
+        .joinpath("src", "skills", "qq", "SKILL.md")
+        .read_text(encoding="utf-8")
+    )
+
+    assert "QQChannel.send" in skill
+    assert "uv run python ./scripts/qq_send.py" not in skill
+    assert "Do not construct or pass `msg_seq`" in skill

--- a/packages/bub-qq/tests/test_webhook.py
+++ b/packages/bub-qq/tests/test_webhook.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+
+from bub_qq.config import QQConfig
+from bub_qq.webhook import QQWebhookServer
+
+
+def test_schedule_payload_runs_callback_on_loop() -> None:
+    async def _run() -> None:
+        received: list[dict[str, object]] = []
+
+        async def on_payload(payload: dict[str, object]) -> None:
+            received.append(payload)
+
+        server = QQWebhookServer(QQConfig(secret="secret"), on_payload)
+        server._loop = asyncio.get_running_loop()
+
+        payload = {"op": 0, "t": "C2C_MESSAGE_CREATE", "d": {"id": "event-1"}}
+        server._schedule_payload(payload)
+        await asyncio.sleep(0)
+
+        assert received == [payload]
+
+    asyncio.run(_run())
+
+
+def test_schedule_payload_requires_running_loop() -> None:
+    async def on_payload(payload: dict[str, object]) -> None:
+        del payload
+
+    server = QQWebhookServer(QQConfig(secret="secret"), on_payload)
+
+    try:
+        server._schedule_payload({"op": 0})
+    except RuntimeError as exc:
+        assert "loop not ready" in str(exc)
+    else:
+        raise AssertionError("expected scheduling without loop to fail")
+
+
+def test_log_callback_result_swallows_handler_errors() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        future: asyncio.Future[None] = loop.create_future()
+        future.set_exception(RuntimeError("boom"))
+
+        server = QQWebhookServer(QQConfig(secret="secret"), lambda payload: _noop(payload))
+        server._log_callback_result(future, op=0, event_type="C2C_MESSAGE_CREATE")
+    finally:
+        loop.close()
+
+
+async def _noop(payload: dict[str, object]) -> None:
+    del payload

--- a/packages/bub-qq/tests/test_webhook.py
+++ b/packages/bub-qq/tests/test_webhook.py
@@ -13,7 +13,7 @@ def test_schedule_payload_runs_callback_on_loop() -> None:
         async def on_payload(payload: dict[str, object]) -> None:
             received.append(payload)
 
-        server = QQWebhookServer(QQConfig(secret="secret"), on_payload)
+        server = QQWebhookServer(QQConfig(secret="secret", receive_mode="webhook"), on_payload)
         server._loop = asyncio.get_running_loop()
 
         payload = {"op": 0, "t": "C2C_MESSAGE_CREATE", "d": {"id": "event-1"}}
@@ -29,7 +29,7 @@ def test_schedule_payload_requires_running_loop() -> None:
     async def on_payload(payload: dict[str, object]) -> None:
         del payload
 
-    server = QQWebhookServer(QQConfig(secret="secret"), on_payload)
+    server = QQWebhookServer(QQConfig(secret="secret", receive_mode="webhook"), on_payload)
 
     try:
         server._schedule_payload({"op": 0})
@@ -45,7 +45,10 @@ def test_log_callback_result_swallows_handler_errors() -> None:
         future: asyncio.Future[None] = loop.create_future()
         future.set_exception(RuntimeError("boom"))
 
-        server = QQWebhookServer(QQConfig(secret="secret"), lambda payload: _noop(payload))
+        server = QQWebhookServer(
+            QQConfig(secret="secret", receive_mode="webhook"),
+            lambda payload: _noop(payload),
+        )
         server._log_callback_result(future, op=0, event_type="C2C_MESSAGE_CREATE")
     finally:
         loop.close()

--- a/packages/bub-qq/tests/test_websocket.py
+++ b/packages/bub-qq/tests/test_websocket.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+
+from bub_qq.config import QQConfig
+from bub_qq.websocket import QQWebSocketClient
+from bub_qq.websocket import _ShardSpec
+from bub_qq.websocket import _ShardState
+
+
+class OpenAPIStub:
+    def __init__(self, payloads: dict[str, dict[str, object]] | None = None) -> None:
+        self.payloads = payloads or {}
+        self.calls: list[str] = []
+
+    async def get(self, path: str, *, params: dict[str, object] | None = None) -> dict[str, object]:
+        del params
+        self.calls.append(path)
+        return self.payloads[path]
+
+    async def get_access_token(self) -> str:
+        return "token"
+
+
+class WebSocketStub:
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, object]] = []
+
+    async def send_json(self, payload: dict[str, object]) -> None:
+        self.payloads.append(payload)
+
+
+class ManualClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+async def _on_payload(payload: dict[str, object]) -> None:
+    del payload
+
+
+def test_resolve_shard_specs_uses_gateway_endpoint_when_unsharded() -> None:
+    async def _run() -> None:
+        openapi = OpenAPIStub(
+            {
+                "/gateway": {
+                    "url": "wss://api.sgroup.qq.com/websocket/",
+                }
+            }
+        )
+        client = QQWebSocketClient(QQConfig(), openapi, _on_payload)  # type: ignore[arg-type]
+
+        specs = await client._resolve_shard_specs()
+
+        assert openapi.calls == ["/gateway"]
+        assert len(specs) == 1
+        assert specs[0].use_shard is False
+        assert specs[0].shard is None
+
+    asyncio.run(_run())
+
+
+def test_resolve_shard_specs_creates_one_worker_per_recommended_shard() -> None:
+    async def _run() -> None:
+        openapi = OpenAPIStub(
+            {
+                "/gateway/bot": {
+                    "url": "wss://api.sgroup.qq.com/websocket/",
+                    "shards": 3,
+                    "session_start_limit": {
+                        "total": 1000,
+                        "remaining": 999,
+                        "reset_after": 14400000,
+                        "max_concurrency": 2,
+                    },
+                }
+            }
+        )
+        client = QQWebSocketClient(
+            QQConfig(websocket_use_shard_gateway=True),
+            openapi,
+            _on_payload,
+        )  # type: ignore[arg-type]
+
+        specs = await client._resolve_shard_specs()
+
+        assert openapi.calls == ["/gateway/bot"]
+        assert [spec.shard for spec in specs] == [(0, 3), (1, 3), (2, 3)]
+        assert all(spec.max_concurrency == 2 for spec in specs)
+
+    asyncio.run(_run())
+
+
+def test_identify_uses_current_shard_index_and_total() -> None:
+    async def _run() -> None:
+        openapi = OpenAPIStub()
+        client = QQWebSocketClient(
+            QQConfig(websocket_use_shard_gateway=True),
+            openapi,
+            _on_payload,
+        )  # type: ignore[arg-type]
+        ws = WebSocketStub()
+
+        await client._identify_or_resume(
+            ws,  # type: ignore[arg-type]
+            _ShardSpec(
+                index=2,
+                total=5,
+                url="wss://api.sgroup.qq.com/websocket/",
+                use_shard=True,
+                max_concurrency=None,
+            ),
+            _ShardState(),
+        )
+
+        assert ws.payloads == [
+            {
+                "op": 2,
+                "d": {
+                    "token": "QQBot token",
+                    "intents": 1 << 25,
+                    "properties": {
+                        "$os": "macos",
+                        "$browser": "bub-qq",
+                        "$device": "bub-qq",
+                    },
+                    "shard": [2, 5],
+                },
+            }
+        ]
+
+    asyncio.run(_run())
+
+
+def test_identify_rate_limit_waits_for_next_window() -> None:
+    async def _run() -> None:
+        clock = ManualClock()
+        client = QQWebSocketClient(
+            QQConfig(),
+            OpenAPIStub(),
+            _on_payload,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )  # type: ignore[arg-type]
+
+        await client._await_identify_slot(1)
+        await client._await_identify_slot(1)
+
+        assert clock.sleeps == [5.0]
+        assert clock.now == 5.0
+
+    asyncio.run(_run())

--- a/packages/bub-qq/tests/test_websocket.py
+++ b/packages/bub-qq/tests/test_websocket.py
@@ -56,7 +56,11 @@ def test_resolve_shard_specs_uses_gateway_endpoint_when_unsharded() -> None:
                 }
             }
         )
-        client = QQWebSocketClient(QQConfig(), openapi, _on_payload)  # type: ignore[arg-type]
+        client = QQWebSocketClient(
+            QQConfig(receive_mode="websocket"),
+            openapi,
+            _on_payload,
+        )  # type: ignore[arg-type]
 
         specs = await client._resolve_shard_specs()
 
@@ -85,7 +89,7 @@ def test_resolve_shard_specs_creates_one_worker_per_recommended_shard() -> None:
             }
         )
         client = QQWebSocketClient(
-            QQConfig(websocket_use_shard_gateway=True),
+            QQConfig(receive_mode="websocket", websocket_use_shard_gateway=True),
             openapi,
             _on_payload,
         )  # type: ignore[arg-type]
@@ -103,7 +107,7 @@ def test_identify_uses_current_shard_index_and_total() -> None:
     async def _run() -> None:
         openapi = OpenAPIStub()
         client = QQWebSocketClient(
-            QQConfig(websocket_use_shard_gateway=True),
+            QQConfig(receive_mode="websocket", websocket_use_shard_gateway=True),
             openapi,
             _on_payload,
         )  # type: ignore[arg-type]
@@ -144,7 +148,7 @@ def test_identify_rate_limit_waits_for_next_window() -> None:
     async def _run() -> None:
         clock = ManualClock()
         client = QQWebSocketClient(
-            QQConfig(),
+            QQConfig(receive_mode="websocket"),
             OpenAPIStub(),
             _on_payload,
             monotonic=clock.monotonic,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "bub-codex",
     "bub-discord",
     "bub-dingtalk",
+    "bub-qq",
     "bub-schedule",
     "bub-tapestore-sqlalchemy",
     "bub-tapestore-sqlite",
@@ -27,6 +28,7 @@ bub-tg-feed = { workspace = true }
 bub-codex = { workspace = true }
 bub-discord = { workspace = true }
 bub-dingtalk = { workspace = true }
+bub-qq = { workspace = true }
 bub-schedule = { workspace = true }
 bub-tapestore-sqlalchemy = { workspace = true }
 bub-tapestore-sqlite = { workspace = true }

--- a/uv.lock
+++ b/uv.lock
@@ -434,18 +434,14 @@ version = "0.1.0"
 source = { editable = "packages/bub-qq" }
 dependencies = [
     { name = "aiohttp" },
-    { name = "bub" },
     { name = "cryptography" },
-    { name = "httpx" },
     { name = "pydantic-settings" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "bub", git = "https://github.com/bubbuild/bub.git" },
     { name = "cryptography", specifier = ">=45.0.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "bub-dingtalk",
     "bub-discord",
     "bub-feishu",
+    "bub-qq",
     "bub-schedule",
     "bub-session-prompt",
     "bub-tapestore-sqlalchemy",
@@ -359,6 +360,7 @@ dependencies = [
     { name = "bub-dingtalk" },
     { name = "bub-discord" },
     { name = "bub-feishu" },
+    { name = "bub-qq" },
     { name = "bub-schedule" },
     { name = "bub-session-prompt" },
     { name = "bub-tapestore-sqlalchemy" },
@@ -374,6 +376,7 @@ requires-dist = [
     { name = "bub-dingtalk", editable = "packages/bub-dingtalk" },
     { name = "bub-discord", editable = "packages/bub-discord" },
     { name = "bub-feishu", editable = "packages/bub-feishu" },
+    { name = "bub-qq", editable = "packages/bub-qq" },
     { name = "bub-schedule", editable = "packages/bub-schedule" },
     { name = "bub-session-prompt", editable = "packages/bub-session-prompt" },
     { name = "bub-tapestore-sqlalchemy", editable = "packages/bub-tapestore-sqlalchemy" },
@@ -422,6 +425,27 @@ dependencies = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lark-oapi", specifier = ">=1.4.20" },
+    { name = "pydantic-settings", specifier = ">=2.10.1" },
+]
+
+[[package]]
+name = "bub-qq"
+version = "0.1.0"
+source = { editable = "packages/bub-qq" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "bub" },
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "pydantic-settings" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "bub", git = "https://github.com/bubbuild/bub.git" },
+    { name = "cryptography", specifier = ">=45.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
 ]
 
@@ -830,7 +854,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -839,7 +862,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -848,7 +870,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -857,7 +878,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },


### PR DESCRIPTION
## Summary

- add `bub-qq`, a QQ Open Platform channel adapter for Bub
- support QQ C2C inbound receive and passive reply flows
- support both webhook and websocket receive modes with explicit configuration
- add auth, OpenAPI, webhook, websocket, gateway, signature, and C2C service coverage
- document installation, configuration, current coverage, and current limitations

## Notes

- `BUB_QQ_RECEIVE_MODE` is required because QQ treats webhook and websocket callback delivery as mutually exclusive modes
- webhook support currently covers validation and the current basic `{"op":12}` acknowledgement flow
- current limitations are documented in `packages/bub-qq/README.md`

## Testing

- added tests for config, auth, signatures, channel behavior, webhook flow, websocket flow, gateway handling, and C2C services