### PR TITLE
fix: align qq c2c replies with msg_id and msg_seq semantics

### DIFF
--- a/packages/bub-qq/src/bub_qq/c2c.py
+++ b/packages/bub-qq/src/bub_qq/c2c.py
@@ -24,9 +24,9 @@ from .send_errors import log_send_error
 @dataclass
 class QQC2CSessionState:
     latest_message_id_by_session: dict[str, str]
-    latest_sequence_by_session: dict[str, int]
+    latest_sequence_by_session_and_msg_id: dict[tuple[str, str], int]
     latest_timestamp_by_session: dict[str, str]
-    send_record_by_session_and_msg_id: dict[tuple[str, str], "QQC2CSendRecord"]
+    send_record_by_session_msg_id_and_seq: dict[tuple[str, str, int], "QQC2CSendRecord"]
 
 
 @dataclass
@@ -148,7 +148,10 @@ class QQC2CSendService:
             return None
 
         content_hash = hash_c2c_content(content)
-        send_record = self._state.send_record_by_session_and_msg_id.get((session_id, msg_id))
+        msg_seq = next_c2c_msg_seq(self._state, session_id, msg_id)
+        send_record = self._state.send_record_by_session_msg_id_and_seq.get(
+            (session_id, msg_id, msg_seq)
+        )
         if send_record is not None:
             if send_record.content_hash == content_hash:
                 logger.info(
@@ -161,17 +164,15 @@ class QQC2CSendService:
                 )
                 return build_already_sent_result(send_record)
             logger.warning(
-                "qq.send duplicate session_id={} openid={} msg_id={} reason=duplicate_reply_blocked source=local_dedup_hit previous_msg_seq={} previous_content_hash={} content_hash={}",
+                "qq.send duplicate session_id={} openid={} msg_id={} reason=duplicate_msg_seq_blocked source=local_dedup_hit msg_seq={} previous_content_hash={} content_hash={}",
                 session_id,
                 openid,
                 msg_id,
-                send_record.msg_seq,
+                msg_seq,
                 send_record.content_hash,
                 content_hash,
             )
-            return {"status": "duplicate_reply_blocked"}
-
-        msg_seq = next_c2c_msg_seq(self._state, session_id)
+            return {"status": "duplicate_msg_seq_blocked"}
         try:
             result = await self._openapi.post_c2c_text_message(
                 openid=openid,
@@ -195,7 +196,7 @@ class QQC2CSendService:
                     msg_seq=msg_seq,
                     result={},
                 )
-                self._state.send_record_by_session_and_msg_id[(session_id, msg_id)] = duplicate_record
+                self._state.send_record_by_session_msg_id_and_seq[(session_id, msg_id, msg_seq)] = duplicate_record
                 return build_already_sent_result(duplicate_record)
             log_send_error(
                 exc,
@@ -213,7 +214,7 @@ class QQC2CSendService:
             msg_seq=msg_seq,
             result=dict(result),
         )
-        self._state.send_record_by_session_and_msg_id[(session_id, msg_id)] = send_record
+        self._state.send_record_by_session_msg_id_and_seq[(session_id, msg_id, msg_seq)] = send_record
         logger.info(
             "qq.send success session_id={} openid={} msg_id={} msg_seq={} response_id={}",
             session_id,
@@ -294,9 +295,10 @@ def resolve_c2c_openid(*, channel_name: str, session_id: str, chat_id: str) -> s
     return None
 
 
-def next_c2c_msg_seq(state: QQC2CSessionState, session_id: str) -> int:
-    current = state.latest_sequence_by_session.get(session_id, 0) + 1
-    state.latest_sequence_by_session[session_id] = current
+def next_c2c_msg_seq(state: QQC2CSessionState, session_id: str, msg_id: str) -> int:
+    key = (session_id, msg_id)
+    current = state.latest_sequence_by_session_and_msg_id.get(key, 0) + 1
+    state.latest_sequence_by_session_and_msg_id[key] = current
     return current
 
 

--- a/packages/bub-qq/src/bub_qq/channel.py
+++ b/packages/bub-qq/src/bub_qq/channel.py
@@ -36,9 +36,9 @@ class QQChannel(Channel):
         self._c2c_deduper = QQC2CDeduper(self._config.inbound_dedupe_size)
         self._c2c_state = QQC2CSessionState(
             latest_message_id_by_session={},
-            latest_sequence_by_session={},
+            latest_sequence_by_session_and_msg_id={},
             latest_timestamp_by_session={},
-            send_record_by_session_and_msg_id={},
+            send_record_by_session_msg_id_and_seq={},
         )
         self._c2c_inbound = QQC2CInboundService(
             channel_name=self.name,

--- a/packages/bub-qq/tests/test_c2c_services.py
+++ b/packages/bub-qq/tests/test_c2c_services.py
@@ -56,9 +56,9 @@ class FailingOpenAPIStub:
 def _state() -> QQC2CSessionState:
     return QQC2CSessionState(
         latest_message_id_by_session={},
-        latest_sequence_by_session={},
+        latest_sequence_by_session_and_msg_id={},
         latest_timestamp_by_session={},
-        send_record_by_session_and_msg_id={},
+        send_record_by_session_msg_id_and_seq={},
     )
 
 
@@ -88,7 +88,7 @@ def test_c2c_inbound_service_parses_and_remembers_session() -> None:
     assert message.message_id == "message-1"
     assert channel_message.session_id == "qq:c2c:user-openid"
     assert state.latest_message_id_by_session["qq:c2c:user-openid"] == "message-1"
-    assert state.latest_sequence_by_session == {}
+    assert state.latest_sequence_by_session_and_msg_id == {}
 
 
 def test_c2c_inbound_service_dedupes_repeated_messages() -> None:
@@ -168,7 +168,76 @@ def test_c2c_send_service_starts_msg_seq_at_one_after_inbound_transport_sequence
                 "msg_seq": 1,
             }
         ]
-        assert state.latest_sequence_by_session["qq:c2c:user-openid"] == 1
+        assert state.latest_sequence_by_session_and_msg_id[
+            ("qq:c2c:user-openid", "message-1")
+        ] == 1
+
+    asyncio.run(_run())
+
+
+def test_c2c_send_service_resets_msg_seq_for_new_inbound_msg_id() -> None:
+    async def _run() -> None:
+        state = _state()
+        openapi = OpenAPIStub()
+        inbound = QQC2CInboundService(channel_name="qq", deduper=QQC2CDeduper(16), state=state)
+        service = QQC2CSendService(
+            channel_name="qq",
+            receive_mode="webhook",
+            state=state,
+            openapi=openapi,
+        )
+
+        assert inbound.parse_inbound(_payload("message-1")) is not None
+        first = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="first reply",
+                channel="qq",
+            )
+        )
+        second = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="second reply",
+                channel="qq",
+            )
+        )
+
+        assert inbound.parse_inbound(_payload("message-2")) is not None
+        third = await service.send(
+            ChannelMessage(
+                session_id="qq:c2c:user-openid",
+                chat_id="c2c:user-openid",
+                content="reply for new inbound message",
+                channel="qq",
+            )
+        )
+
+        assert first == {"id": "reply-1"}
+        assert second == {"id": "reply-1"}
+        assert third == {"id": "reply-1"}
+        assert openapi.calls == [
+            {
+                "openid": "user-openid",
+                "content": "first reply",
+                "msg_id": "message-1",
+                "msg_seq": 1,
+            },
+            {
+                "openid": "user-openid",
+                "content": "second reply",
+                "msg_id": "message-1",
+                "msg_seq": 2,
+            },
+            {
+                "openid": "user-openid",
+                "content": "reply for new inbound message",
+                "msg_id": "message-2",
+                "msg_seq": 1,
+            },
+        ]
 
     asyncio.run(_run())
 
@@ -208,7 +277,7 @@ def test_c2c_send_service_strips_qq_wrapper_prefix_before_sending() -> None:
     asyncio.run(_run())
 
 
-def test_c2c_send_service_returns_already_sent_for_same_content() -> None:
+def test_c2c_send_service_allows_multiple_replies_for_same_msg_id() -> None:
     async def _run() -> None:
         state = _state()
         state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
@@ -233,63 +302,25 @@ def test_c2c_send_service_returns_already_sent_for_same_content() -> None:
             ChannelMessage(
                 session_id="qq:c2c:user-openid",
                 chat_id="c2c:user-openid",
-                content="hello",
+                content="job finished",
                 channel="qq",
             )
         )
 
         assert first == {"id": "reply-1"}
-        assert second == {"id": "reply-1", "status": "already_sent"}
+        assert second == {"id": "reply-1"}
         assert openapi.calls == [
             {
                 "openid": "user-openid",
                 "content": "hello",
                 "msg_id": "message-1",
                 "msg_seq": 1,
-            }
-        ]
-
-    asyncio.run(_run())
-
-
-def test_c2c_send_service_rejects_duplicate_reply_with_different_content() -> None:
-    async def _run() -> None:
-        state = _state()
-        state.latest_message_id_by_session["qq:c2c:user-openid"] = "message-1"
-        state.latest_timestamp_by_session["qq:c2c:user-openid"] = "2099-01-01T00:00:00+00:00"
-        openapi = OpenAPIStub()
-        service = QQC2CSendService(
-            channel_name="qq",
-            receive_mode="webhook",
-            state=state,
-            openapi=openapi,
-        )
-
-        first = await service.send(
-            ChannelMessage(
-                session_id="qq:c2c:user-openid",
-                chat_id="c2c:user-openid",
-                content="hello",
-                channel="qq",
-            )
-        )
-        second = await service.send(
-            ChannelMessage(
-                session_id="qq:c2c:user-openid",
-                chat_id="c2c:user-openid",
-                content="different reply",
-                channel="qq",
-            )
-        )
-
-        assert first == {"id": "reply-1"}
-        assert second == {"status": "duplicate_reply_blocked"}
-        assert openapi.calls == [
+            },
             {
                 "openid": "user-openid",
-                "content": "hello",
+                "content": "job finished",
                 "msg_id": "message-1",
-                "msg_seq": 1,
+                "msg_seq": 2,
             }
         ]
 
@@ -406,6 +437,6 @@ def test_c2c_send_service_treats_remote_duplicate_as_already_sent() -> None:
 
         assert first == {"status": "already_sent"}
         assert second == {"status": "already_sent"}
-        assert openapi.calls == 1
+        assert openapi.calls == 2
 
     asyncio.run(_run())


### PR DESCRIPTION
Allow multiple C2C replies for the same inbound msg_id by tracking send state per msg_id + msg_seq instead of blocking
different content after the first reply. Also reset reply sequencing for new inbound msg_id values and update C2C service tests accordingly.