### PR TITLE
feat: add wecom channel skill and proactive send support

### DIFF
--- a/packages/bub-wecom/pyproject.toml
+++ b/packages/bub-wecom/pyproject.toml
@@ -17,3 +17,7 @@ wecom = "bub_wecom.plugin"
 [build-system]
 requires = ["uv_build>=0.10.4,<0.11.0"]
 build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = ["bub_wecom", "skills.wecom"]
+source-include = ["src/skills/wecom/SKILL.md", "src/skills/wecom/scripts/*.py"]

--- a/packages/bub-wecom/src/bub_wecom/channel.py
+++ b/packages/bub-wecom/src/bub_wecom/channel.py
@@ -278,28 +278,48 @@ class WeComChannel(Channel):
         self._started = False
 
     async def send(self, message: ChannelMessage) -> None:
-        if self._client is None:
-            raise RuntimeError("wecom client is not initialized")
+        content = (message.content or "").strip()
         stream_session = self._stream_sessions.pop(message.session_id, None)
-        if stream_session is not None and hasattr(self._client, "reply_stream"):
+        if stream_session is not None:
+            if self._client is None:
+                raise RuntimeError("wecom client is not initialized")
             await self._client.reply_stream(
                 stream_session.frame,
                 stream_session.stream_id,
-                message.content[:4000],
+                content[:4000],
                 True,
             )
             return
+
         chat_id = message.chat_id or self._session_chat_id(message.session_id)
         if not chat_id:
             logger.warning("wecom.outbound missing chat_id session_id={}", message.session_id)
             return
-        await self._client.send_message(
+        if not content:
+            logger.warning("wecom.outbound skipping empty content session_id={}", message.session_id)
+            return
+
+        logger.info(
+            "wecom.outbound proactive_send session_id={} chat_id={} content_len={}",
+            message.session_id,
             chat_id,
-            {
-                "msgtype": "markdown",
-                "markdown": {"content": message.content[:4000]},
-            },
+            len(content),
         )
+        try:
+            from skills.wecom.scripts.wecom_send import send_message as send_proactive_message
+
+            await send_proactive_message(
+                self._settings.bot_id,
+                self._settings.secret,
+                chat_id,
+                content[:4000],
+                message_format="markdown",
+                websocket_url=self._settings.websocket_url,
+            )
+            logger.info("wecom.outbound proactive_send success chat_id={}", chat_id)
+        except Exception as e:
+            logger.error("wecom.outbound proactive_send failed chat_id={} error={}", chat_id, e)
+            raise
 
     def _register_handlers(self) -> None:
         if self._client is None:

--- a/packages/bub-wecom/src/skills/wecom/SKILL.md
+++ b/packages/bub-wecom/src/skills/wecom/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: wecom
+description:
+  WeCom channel skill. Return normal replies directly. For proactive sends such as scheduled jobs,
+  use the packaged wecom_send.py script.
+metadata:
+  channel: wecom
+---
+
+# WeCom Skill
+
+Use this skill when the current conversation is on WeCom.
+
+## Execution Policy
+
+- Normal replies in the current WeCom conversation: return the final text directly.
+- Proactive sends outside the current turn, such as scheduled jobs, tool notifications, and progress updates: call `wecom_send.py`.
+- Use `chat_id` from runtime context when available. If only `session_id` exists, derive it from `wecom:<chat_id>`.
+- Keep the response text-first. Markdown is supported.
+- Do not construct `req_id`, `stream_id`, or raw WebSocket payloads.
+
+## Current Context
+
+Current WeCom message JSON may include:
+
+- `message`
+- `message_id`
+- `message_type`
+- `sender_id`
+- `chat_type`
+- `quote`
+
+## Script Usage
+
+```bash
+uv run ${SKILL_DIR}/scripts/wecom_send.py \
+  --chat-id <CHAT_ID> \
+  --content "<TEXT>"
+```
+
+Multi-line content:
+
+```bash
+uv run ${SKILL_DIR}/scripts/wecom_send.py \
+  --chat-id <CHAT_ID> \
+  --content "$(cat <<'EOF'
+Task finished.
+- 12 checks passed
+- 0 failures
+EOF
+)"
+```

--- a/packages/bub-wecom/src/skills/wecom/__init__.py
+++ b/packages/bub-wecom/src/skills/wecom/__init__.py
@@ -1,0 +1,1 @@
+"""WeCom skill package."""

--- a/packages/bub-wecom/src/skills/wecom/scripts/__init__.py
+++ b/packages/bub-wecom/src/skills/wecom/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""WeCom skill scripts package."""

--- a/packages/bub-wecom/src/skills/wecom/scripts/wecom_send.py
+++ b/packages/bub-wecom/src/skills/wecom/scripts/wecom_send.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env uv run
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "wecom-aibot-python-sdk>=1.0.2",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import os
+import sys
+from collections.abc import Awaitable
+from typing import Any, cast
+
+from aibot import WSClient, WSClientOptions
+
+
+def _register_handler(client: WSClient, event: str, handler: Any) -> None:
+    registration = getattr(client, "on")
+    try:
+        registration(event, handler)
+    except TypeError:
+        decorator = registration(event)
+        decorator(handler)
+
+
+def _prepare_auth_waiter(client: WSClient) -> tuple[asyncio.Event, list[BaseException]]:
+    authenticated = asyncio.Event()
+    errors: list[BaseException] = []
+
+    def on_authenticated() -> None:
+        authenticated.set()
+
+    def on_error(error: Exception) -> None:
+        errors.append(error)
+        authenticated.set()
+
+    def on_disconnected(reason: str) -> None:
+        errors.append(RuntimeError(f"WeCom websocket disconnected before authentication: {reason}"))
+        authenticated.set()
+
+    _register_handler(client, "authenticated", on_authenticated)
+    _register_handler(client, "error", on_error)
+    _register_handler(client, "disconnected", on_disconnected)
+    return authenticated, errors
+
+
+async def _wait_for_authentication(
+    authenticated: asyncio.Event,
+    errors: list[BaseException],
+    timeout_seconds: float = 10.0,
+) -> None:
+    await asyncio.wait_for(authenticated.wait(), timeout=timeout_seconds)
+    if errors:
+        raise errors[0]
+
+
+async def _disconnect_client(client: WSClient) -> None:
+    result = client.disconnect()
+    if inspect.isawaitable(result):
+        await cast(Awaitable[Any], result)
+
+
+async def send_message(
+    bot_id: str,
+    secret: str,
+    chat_id: str,
+    content: str,
+    *,
+    message_format: str = "markdown",
+    websocket_url: str | None = None,
+) -> None:
+    body_key = "markdown" if message_format == "markdown" else "text"
+    client = WSClient(
+        WSClientOptions(
+            bot_id=bot_id,
+            secret=secret,
+            ws_url=websocket_url or "wss://openws.work.weixin.qq.com",
+            max_reconnect_attempts=0,
+        )
+    )
+    authenticated, errors = _prepare_auth_waiter(client)
+    await client.connect()
+    try:
+        await _wait_for_authentication(authenticated, errors)
+        await client.send_message(
+            chat_id,
+            {
+                "msgtype": message_format,
+                body_key: {"content": content},
+            },
+        )
+        await asyncio.sleep(0.2)
+    finally:
+        await _disconnect_client(client)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send a proactive message to WeCom")
+    parser.add_argument("--chat-id", "-c", required=True, help="Target WeCom chat ID")
+    parser.add_argument("--content", "-m", required=True, help="Content to send")
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "text"),
+        default="markdown",
+        help="Outbound WeCom message format",
+    )
+    parser.add_argument(
+        "--bot-id",
+        default=os.environ.get("BUB_WECOM_BOT_ID"),
+        help="WeCom bot ID",
+    )
+    parser.add_argument(
+        "--secret",
+        default=os.environ.get("BUB_WECOM_SECRET"),
+        help="WeCom bot secret",
+    )
+    parser.add_argument(
+        "--websocket-url",
+        default=os.environ.get("BUB_WECOM_WEBSOCKET_URL"),
+        help="WeCom websocket URL",
+    )
+    args = parser.parse_args()
+
+    if not args.bot_id or not args.secret:
+        print("Error: BUB_WECOM_BOT_ID and BUB_WECOM_SECRET are required")
+        sys.exit(1)
+
+    try:
+        asyncio.run(
+            send_message(
+                args.bot_id,
+                args.secret,
+                args.chat_id,
+                args.content,
+                message_format=args.format,
+                websocket_url=args.websocket_url,
+            )
+        )
+        print(f"Message sent to {args.chat_id}")
+    except Exception as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
- add packaged WeCom skill guidance
- add proactive send script for WeCom
- align WeCom outbound delivery with packaged skill script
- include packaged skill resources in build output

## Notes
- normal in-turn replies still use standard channel outbound
- proactive sends such as scheduled jobs use the packaged  path