### PR TITLE
Fix codex plugin init and session id parse errors

### DIFF
--- a/packages/bub-codex/src/bub_codex/plugin.py
+++ b/packages/bub-codex/src/bub_codex/plugin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import json

--- a/packages/bub-codex/src/bub_codex/plugin.py
+++ b/packages/bub-codex/src/bub_codex/plugin.py
@@ -97,14 +97,18 @@ async def run_model(prompt: str, session_id: str, state: State) -> str:
         process = await asyncio.create_subprocess_exec(
             *command,
             stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             cwd=str(workspace),
         )
-        stdout, _ = await process.communicate()
+        stdout, stderr = await process.communicate()
     output_blocks: list[str] = []
     if stdout:
         output_blocks.append(stdout.decode())
-        first_line = stdout.decode().splitlines()[0]
-        if "thread_id" in first_line:
-            thread_id = json.loads(first_line)["thread_id"]
-            _save_thread_id(session_id, thread_id, state)
+    if stderr:
+        stderr_text = stderr.decode()
+        for line in stderr_text.splitlines():
+            if line.startswith("session id:"):
+                thread_id = line.split(":", 1)[1].strip()
+                _save_thread_id(session_id, thread_id, state)
+                break
     return "\n".join(output_blocks)

--- a/packages/bub-codex/tests/test_plugin.py
+++ b/packages/bub-codex/tests/test_plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 from pathlib import Path
 
 import pytest
@@ -34,14 +35,14 @@ def test_run_model_delegates_internal_commands_to_runtime_agent() -> None:
 def test_run_model_uses_codex_for_normal_prompt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    calls: list[tuple[tuple[object, ...], str | None]] = []
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     class FakeProcess:
         async def communicate(self) -> tuple[bytes, bytes]:
             return (b"codex-output\n", b"")
 
-    async def fake_create_subprocess_exec(*args, stdout=None, cwd=None):
-        calls.append((args, cwd))
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
         return FakeProcess()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
@@ -52,7 +53,33 @@ def test_run_model_uses_codex_for_normal_prompt(
 
     assert result == "codex-output\n"
     assert calls
-    args, cwd = calls[0]
+    args, kwargs = calls[0]
     assert args[:2] == ("codex", "e")
     assert args[-1] == "hello"
-    assert cwd == str(tmp_path)
+    assert kwargs["cwd"] == str(tmp_path)
+    assert kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert kwargs["stderr"] == asyncio.subprocess.PIPE
+
+
+def test_run_model_saves_session_id_from_stderr(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeProcess:
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return (
+                b"codex-output\n",
+                b"booting\nsession id: thread-123\nconnected\n",
+            )
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(plugin, "with_bub_skills", lambda workspace: contextlib.nullcontext())
+
+    state = {"_runtime_workspace": str(tmp_path)}
+    result = asyncio.run(plugin.run_model("hello", session_id="session-3", state=state))
+
+    assert result == "codex-output\n"
+    threads_file = tmp_path / plugin.THREADS_FILE
+    assert json.loads(threads_file.read_text()) == {"session-3": "thread-123"}


### PR DESCRIPTION
1. fix(bub-codex): add missing from \_\_future__ import annotations

Without this import, the plugin failing to load with:

        WARNING - Failed to load plugin 'codex': name 'Agent' is not defined

2. fix(bub-codex): extract thread id from stderr session id line

The old code expected the first line of stdout to be JSON containing thread_id, but codex e does not output JSON by default.

Consequently, _save_thread_id was never called, .bub-codex-threads.json was never created, and each turn started a new Codex session with no conversation history.

Fix by reading the session id line from stderr instead.