### PR TITLE
feat(dingtalk): send local images in replies via markdown syntax

### DIFF
--- a/packages/bub-dingtalk/README.md
+++ b/packages/bub-dingtalk/README.md
@@ -56,6 +56,29 @@ Inbound messages keep the original DingTalk text as plain string `content`.
 - Delegates outbound delivery to `skills.dingtalk.scripts.dingtalk_send.send_message()`.
 - Uses standard TLS verification; there is no global SSL monkey patching or per-request verification bypass.
 
+### Image Support
+
+Local image files referenced via markdown syntax in the reply content are
+detected and delivered as native DingTalk image messages:
+
+```markdown
+Here's the chart:
+![sales](/tmp/sales_report.png)
+```
+
+The channel:
+
+1. Strips the `![alt](path)` markdown from the text.
+2. Uploads each local file via `POST https://oapi.dingtalk.com/media/upload`
+   to obtain a `media_id`.
+3. Sends a `sampleImageMsg` with `photoURL = <media_id>` (works in both
+   1:1 and group chats; `media_id` is preferred over raw URLs because
+   DingTalk cannot fetch `http://ip:port` or local-network images).
+
+Supported formats: `jpg`, `gif`, `png`, `bmp` (max 20MB each). `http(s)`/`data:`
+URLs and non-existent local paths are left untouched in the text. See
+`src/skills/dingtalk/SKILL.md` for the agent-facing contract.
+
 ## Verify Inbound Flow
 
 The packaged skill resources live under `src/skills/dingtalk`.

--- a/packages/bub-dingtalk/src/bub_dingtalk/channel.py
+++ b/packages/bub-dingtalk/src/bub_dingtalk/channel.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import re
+from pathlib import Path
 from typing import Any
 
 import bub
@@ -44,6 +46,54 @@ def _parse_allow_users(value: str) -> set[str]:
     if v == "*":
         return {"*"}
     return {u.strip() for u in v.split(",") if u.strip()}
+
+
+# Markdown image syntax: ![alt](target). We only act on local paths.
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+
+_URL_PREFIXES = ("http://", "https://", "data:")
+
+_EXT_TO_MIME: dict[str, str] = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".bmp": "image/bmp",
+}
+
+
+def _mime_for_path(path: Path) -> str:
+    return _EXT_TO_MIME.get(path.suffix.lower(), "image/png")
+
+
+def _extract_local_images(content: str) -> tuple[str, list[tuple[str, Path]]]:
+    """Pull local-file image references out of markdown text.
+
+    Returns ``(stripped_content, images)`` where ``images`` is a list of
+    ``(alt_text, absolute_path)`` for each local file that exists. Markdown
+    image references pointing at http/https/data URLs, or at non-existent
+    local paths, are left intact in ``stripped_content``.
+    """
+    images: list[tuple[str, Path]] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        alt = match.group(1)
+        raw = match.group(2).strip()
+        if raw.startswith(_URL_PREFIXES):
+            return match.group(0)
+        path_str = raw[7:] if raw.startswith("file://") else raw
+        candidate = Path(path_str).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        if not candidate.is_file():
+            logger.warning("DingTalk image not found, leaving markdown: {}", candidate)
+            return match.group(0)
+        images.append((alt, candidate))
+        return ""
+
+    stripped = _MD_IMAGE_RE.sub(_replace, content)
+    stripped = re.sub(r"\n{3,}", "\n\n", stripped).strip()
+    return stripped, images
 
 
 class DingTalkCallbackHandler(CallbackHandler):
@@ -170,13 +220,21 @@ class DingTalkChannel(Channel):
         logger.info("DingTalk channel stopped")
 
     async def send(self, message: ChannelMessage) -> None:
-        """Send message to DingTalk via skill."""
-        content = (message.content or "").strip()
+        """Send message to DingTalk via skill.
+
+        Detects local image references written as ``![alt](/abs/path.png)``
+        in the content. The text is sent first (with the markdown stripped),
+        then each local image is uploaded and sent as a ``sampleImageMsg``
+        in the order it appeared.
+        """
+        raw_content = message.content or ""
+        content, images = _extract_local_images(raw_content)
         logger.info(
-            "DingTalk send: called session_id={} chat_id={} content_len={}",
+            "DingTalk send: session_id={} chat_id={} content_len={} images={}",
             message.session_id,
             message.chat_id,
             len(content),
+            len(images),
         )
 
         chat_id = message.chat_id or ""
@@ -188,30 +246,71 @@ class DingTalkChannel(Channel):
             )
             return
 
-        if not content:
+        if not content and not images:
             logger.warning(
                 "DingTalk send: skipping empty content session_id={}",
                 message.session_id,
             )
             return
 
-        logger.info(
-            "DingTalk send: sending chat_id={} content_len={}", chat_id, len(content)
+        from skills.dingtalk.scripts.dingtalk_send import (
+            send_image_message,
+            send_message,
+            upload_media,
         )
-        try:
-            from skills.dingtalk.scripts.dingtalk_send import send_message
 
-            await asyncio.to_thread(
-                send_message,
-                self._config.client_id,
-                self._config.client_secret,
-                chat_id,
-                content,
-                title="Bub Reply",
+        if content:
+            logger.info(
+                "DingTalk send: text chat_id={} content_len={}", chat_id, len(content)
             )
-            logger.info("DingTalk send: success chat_id={}", chat_id)
-        except Exception as e:
-            logger.error("DingTalk send failed for chat_id={} error={}", chat_id, e)
+            try:
+                await asyncio.to_thread(
+                    send_message,
+                    self._config.client_id,
+                    self._config.client_secret,
+                    chat_id,
+                    content,
+                    title="Bub Reply",
+                )
+            except Exception as e:
+                logger.error(
+                    "DingTalk send text failed chat_id={} error={}", chat_id, e
+                )
+
+        for alt, image_path in images:
+            logger.info(
+                "DingTalk send: image chat_id={} path={} alt={}",
+                chat_id,
+                image_path,
+                alt,
+            )
+            try:
+                file_bytes = image_path.read_bytes()
+                media_id = await asyncio.to_thread(
+                    upload_media,
+                    self._config.client_id,
+                    self._config.client_secret,
+                    file_bytes,
+                    image_path.name,
+                    _mime_for_path(image_path),
+                )
+                await asyncio.to_thread(
+                    send_image_message,
+                    self._config.client_id,
+                    self._config.client_secret,
+                    chat_id,
+                    media_id,
+                )
+                logger.info(
+                    "DingTalk send: image ok chat_id={} path={}", chat_id, image_path
+                )
+            except Exception as e:
+                logger.error(
+                    "DingTalk send image failed chat_id={} path={} error={}",
+                    chat_id,
+                    image_path,
+                    e,
+                )
 
     async def _on_message(
         self,

--- a/packages/bub-dingtalk/src/skills/dingtalk/SKILL.md
+++ b/packages/bub-dingtalk/src/skills/dingtalk/SKILL.md
@@ -20,6 +20,32 @@ When the message context contains `$dingtalk` and `chat_id`, you are in a DingTa
 
 Example: User asks "What is 2+2?" → You return "4" → The framework sends "4" to DingTalk.
 
+## Sending Images
+
+To include a local image in your reply, use markdown image syntax with a local
+file path:
+
+```
+Here's the chart:
+![sales](/tmp/sales_report.png)
+```
+
+The framework will:
+
+1. Strip the markdown from the text (so the user just sees "Here's the chart:").
+2. Upload the local file to DingTalk via the media upload API.
+3. Send the image as a separate `sampleImageMsg` after the text.
+
+Rules:
+
+- **Absolute local paths** (e.g. `/tmp/result.png`) and `file://` URIs are uploaded.
+- **http(s)/data URLs are left as-is** in the markdown text — DingTalk's markdown
+  renderer decides whether to render them. If you need a guaranteed-delivered
+  image, prefer a local path (and let the framework upload it).
+- Supported formats: `jpg`, `gif`, `png`, `bmp`. Max 20MB per image.
+- Missing files are skipped (the markdown stays in the text and a warning is
+  logged); other replies continue to send.
+
 ## When to Use the Script
 
 Use `dingtalk_send` only when you need to send **from within a tool** (e.g. a progress update during a long-running task, or a status message triggered by another tool).

--- a/packages/bub-dingtalk/src/skills/dingtalk/scripts/dingtalk_send.py
+++ b/packages/bub-dingtalk/src/skills/dingtalk/scripts/dingtalk_send.py
@@ -20,6 +20,7 @@ from typing import Any
 import requests
 
 OPENAPI_BASE = "https://api.dingtalk.com"
+OAPI_BASE = "https://oapi.dingtalk.com"
 TOKEN_URL = f"{OPENAPI_BASE}/v1.0/oauth2/accessToken"
 
 
@@ -48,12 +49,84 @@ def send_message(
     msg_key: str = "sampleMarkdown",
 ) -> dict[str, Any]:
     """Send a markdown message to DingTalk."""
+    return _send_robot_message(
+        client_id,
+        client_secret,
+        chat_id,
+        msg_key,
+        {"text": content, "title": title},
+    )
+
+
+def upload_media(
+    client_id: str,
+    client_secret: str,
+    file_bytes: bytes,
+    filename: str,
+    mime_type: str = "image/png",
+) -> str:
+    """Upload an image to DingTalk and return its media_id.
+
+    Uses the legacy ``/media/upload`` endpoint (multipart/form-data, field name
+    ``media``). The returned ``media_id`` is reusable and can be passed as the
+    ``photoURL`` of a ``sampleImageMsg`` robot message. See:
+    https://open.dingtalk.com/document/orgapp/upload-media-files
+    """
+    token = get_access_token(client_id, client_secret)
+    resp = requests.post(
+        f"{OAPI_BASE}/media/upload",
+        params={"type": "image", "access_token": token},
+        files={"media": (filename, file_bytes, mime_type)},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json() if resp.text else {}
+    errcode = data.get("errcode")
+    if errcode not in (None, 0):
+        raise RuntimeError(
+            f"DingTalk media upload failed: errcode={errcode} "
+            f"errmsg={data.get('errmsg', '')}"
+        )
+    media_id = data.get("media_id")
+    if not media_id:
+        raise RuntimeError(f"DingTalk media upload returned no media_id: {data}")
+    return str(media_id)
+
+
+def send_image_message(
+    client_id: str,
+    client_secret: str,
+    chat_id: str,
+    photo_ref: str,
+) -> dict[str, Any]:
+    """Send a ``sampleImageMsg`` robot message.
+
+    ``photo_ref`` may be either a ``media_id`` returned by :func:`upload_media`
+    or a publicly reachable HTTPS URL. Local file paths are not supported here;
+    upload them first.
+    """
+    return _send_robot_message(
+        client_id,
+        client_secret,
+        chat_id,
+        "sampleImageMsg",
+        {"photoURL": photo_ref},
+    )
+
+
+def _send_robot_message(
+    client_id: str,
+    client_secret: str,
+    chat_id: str,
+    msg_key: str,
+    msg_param: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a robot message to either group or 1:1 based on chat_id prefix."""
     token = get_access_token(client_id, client_secret)
     headers = {
         "Content-Type": "application/json",
         "x-acs-dingtalk-access-token": token,
     }
-    msg_param = {"text": content, "title": title}
 
     if chat_id.startswith("group:"):
         url = f"{OPENAPI_BASE}/v1.0/robot/groupMessages/send"

--- a/packages/bub-dingtalk/tests/test_image_send.py
+++ b/packages/bub-dingtalk/tests/test_image_send.py
@@ -1,0 +1,261 @@
+"""Tests for outbound image extraction and dispatch in DingTalkChannel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bub_dingtalk.channel import (
+    DingTalkChannel,
+    _extract_local_images,
+    _mime_for_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_local_images
+# ---------------------------------------------------------------------------
+
+
+def test_extract_local_images_returns_path_for_existing_local_file(
+    tmp_path: Path,
+) -> None:
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nfakepng")
+
+    content = f"Here is the chart:\n![chart]({img})\nDone."
+    stripped, images = _extract_local_images(content)
+
+    assert stripped == "Here is the chart:\n\nDone."
+    assert len(images) == 1
+    assert images[0][0] == "chart"
+    assert images[0][1] == img
+
+
+def test_extract_local_images_keeps_http_urls() -> None:
+    content = "See ![logo](https://example.com/logo.png) here."
+    stripped, images = _extract_local_images(content)
+
+    assert stripped == content
+    assert images == []
+
+
+def test_extract_local_images_keeps_data_urls() -> None:
+    content = "![pic](data:image/png;base64,iVBORw0KGgo=)"
+    stripped, images = _extract_local_images(content)
+
+    assert stripped == content
+    assert images == []
+
+
+def test_extract_local_images_keeps_missing_local_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.png"
+    content = f"![x]({missing})"
+    stripped, images = _extract_local_images(content)
+
+    assert stripped == content
+    assert images == []
+
+
+def test_extract_local_images_handles_file_scheme(tmp_path: Path) -> None:
+    img = tmp_path / "pic.jpg"
+    img.write_bytes(b"fakejpg")
+    content = f"![pic](file://{img})"
+    stripped, images = _extract_local_images(content)
+
+    assert stripped == ""
+    assert len(images) == 1
+    assert images[0][1] == img
+
+
+def test_extract_local_images_multiple_in_order(tmp_path: Path) -> None:
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.png"
+    a.write_bytes(b"a")
+    b.write_bytes(b"b")
+
+    content = f"first ![a]({a}) middle ![b]({b}) end"
+    stripped, images = _extract_local_images(content)
+
+    assert images[0][1] == a
+    assert images[1][1] == b
+    assert "first" in stripped and "middle" in stripped and "end" in stripped
+    assert "![a]" not in stripped and "![b]" not in stripped
+
+
+def test_mime_for_path_known_extensions() -> None:
+    assert _mime_for_path(Path("x.png")) == "image/png"
+    assert _mime_for_path(Path("x.jpg")) == "image/jpeg"
+    assert _mime_for_path(Path("x.JPEG")) == "image/jpeg"
+    assert _mime_for_path(Path("x.gif")) == "image/gif"
+    assert _mime_for_path(Path("x.bmp")) == "image/bmp"
+
+
+def test_mime_for_path_unknown_defaults_to_png() -> None:
+    assert _mime_for_path(Path("x.webp")) == "image/png"
+
+
+# ---------------------------------------------------------------------------
+# DingTalkChannel.send — dispatch flow
+# ---------------------------------------------------------------------------
+
+
+def _build_channel(monkeypatch: pytest.MonkeyPatch) -> DingTalkChannel:
+    """Construct a DingTalkChannel without running bub's full config loader."""
+    fake_config = SimpleNamespace(
+        client_id="cid",
+        client_secret="csec",
+        allow_users="*",
+    )
+    monkeypatch.setattr(
+        "bub_dingtalk.channel.bub.ensure_config", lambda _cls: fake_config
+    )
+
+    async def _no_receive(_msg):  # pragma: no cover - never invoked here
+        return None
+
+    return DingTalkChannel(_no_receive)
+
+
+def test_send_dispatches_text_then_image_in_order(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import asyncio
+
+    img = tmp_path / "pic.png"
+    img.write_bytes(b"fake-bytes")
+
+    calls: list[tuple[str, tuple, dict]] = []
+
+    def _fake_send_message(cid, secret, chat_id, content, *, title="Bub Reply"):
+        calls.append(("text", (cid, secret, chat_id, content), {"title": title}))
+        return {"ok": True}
+
+    def _fake_upload_media(cid, secret, file_bytes, filename, mime_type):
+        calls.append(
+            (
+                "upload",
+                (cid, secret, len(file_bytes), filename, mime_type),
+                {},
+            )
+        )
+        return "MEDIA_ID_123"
+
+    def _fake_send_image(cid, secret, chat_id, photo_ref):
+        calls.append(("image", (cid, secret, chat_id, photo_ref), {}))
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_message", _fake_send_message
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.upload_media", _fake_upload_media
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_image_message",
+        _fake_send_image,
+    )
+
+    ch = _build_channel(monkeypatch)
+
+    from bub.channels.message import ChannelMessage
+
+    msg = ChannelMessage(
+        session_id="dingtalk:user-1",
+        content=f"see this:\n![pic]({img})",
+        channel="dingtalk",
+        chat_id="user-1",
+    )
+
+    asyncio.run(ch.send(msg))
+
+    # Expect: text first, then upload, then image send
+    assert [c[0] for c in calls] == ["text", "upload", "image"]
+
+    text_call = calls[0]
+    assert text_call[1][2] == "user-1"  # chat_id
+    assert "see this:" in text_call[1][3]
+    assert "![pic]" not in text_call[1][3]
+
+    upload_call = calls[1]
+    assert upload_call[1][3] == "pic.png"
+    assert upload_call[1][4] == "image/png"
+
+    image_call = calls[2]
+    assert image_call[1][2] == "user-1"  # chat_id
+    assert image_call[1][3] == "MEDIA_ID_123"
+
+
+def test_send_image_only_when_text_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import asyncio
+
+    img = tmp_path / "only.png"
+    img.write_bytes(b"x")
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_message",
+        lambda *a, **k: calls.append("text") or {},
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.upload_media",
+        lambda *a, **k: calls.append("upload") or "MID",
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_image_message",
+        lambda *a, **k: calls.append("image") or {},
+    )
+
+    ch = _build_channel(monkeypatch)
+    from bub.channels.message import ChannelMessage
+
+    msg = ChannelMessage(
+        session_id="dingtalk:user-1",
+        content=f"![pic]({img})",
+        channel="dingtalk",
+        chat_id="user-1",
+    )
+
+    asyncio.run(ch.send(msg))
+
+    assert calls == ["upload", "image"]
+
+
+def test_send_skips_missing_file_and_just_sends_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import asyncio
+
+    missing = tmp_path / "ghost.png"
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_message",
+        lambda *a, **k: calls.append("text") or {},
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.upload_media",
+        lambda *a, **k: calls.append("upload") or "MID",
+    )
+    monkeypatch.setattr(
+        "skills.dingtalk.scripts.dingtalk_send.send_image_message",
+        lambda *a, **k: calls.append("image") or {},
+    )
+
+    ch = _build_channel(monkeypatch)
+    from bub.channels.message import ChannelMessage
+
+    msg = ChannelMessage(
+        session_id="dingtalk:user-1",
+        content=f"missing: ![ghost]({missing})",
+        channel="dingtalk",
+        chat_id="user-1",
+    )
+
+    asyncio.run(ch.send(msg))
+
+    assert calls == ["text"]  # no upload/image attempt


### PR DESCRIPTION
## Summary

- `DingTalkChannel.send()` now detects `![alt](/local/path.png)` markdown image references in outbound content and delivers them as native DingTalk image messages.
- Local paths and `file://` URIs are uploaded via `/media/upload` to get a `media_id`, then sent as `sampleImageMsg`. http(s)/`data:` URLs and non-existent files are left intact in the text.
- Adds reusable `upload_media()` and `send_image_message()` helpers in `dingtalk_send.py`; the existing markdown send path is refactored into a shared `_send_robot_message()` helper.

## Why

The previous channel only sent `sampleMarkdown` text. Bub agents replying with local screenshots/charts had no way to push them into a DingTalk chat, and DingTalk's `sampleImageMsg` `photoURL` cannot fetch `http://ip:port` or local-network images, so a media upload flow was required.

## Flow

1. `content` is scanned; local-image markdown is stripped from the text.
2. Text (if non-empty) is sent via `sampleMarkdown`.
3. For each image (in order): `upload_media` → `media_id` → `send_image_message` (`sampleImageMsg` with `photoURL = <media_id>`). A single image failure is logged but does not abort the rest.

## Limits (DingTalk side)

- Formats: `jpg` / `gif` / `png` / `bmp`, ≤ 20MB each.
- Org upload quota: 10,000/year.

## Test plan

- [x] `uv run --isolated --no-project --with-editable ./packages/bub-dingtalk --with pytest python -m pytest packages/bub-dingtalk/tests/ -v` → 16 passed (11 new + 5 existing, no regressions).
- [ ] Manual smoke: set `BUB_DINGTALK_CLIENT_ID/SECRET`, `ALLOW_USERS=*`, ask the agent to reply with `![logo](/abs/path/logo.png)`, confirm text + image arrive in the target chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)