### PR TITLE
fix(wechat): persist token under BUB_HOME

### DIFF
--- a/packages/bub-wechat/README.md
+++ b/packages/bub-wechat/README.md
@@ -31,6 +31,9 @@ Login to WeChat using the provided CLI tool:
 bub login wechat
 ```
 
+The login token is stored at `$BUB_HOME/wechat_token.json`. If `BUB_HOME` is
+not set, it defaults to `~/.bub/wechat_token.json`.
+
 ## Development
 
 - Requires Python 3.12+

--- a/packages/bub-wechat/src/bub_wechat/channel.py
+++ b/packages/bub-wechat/src/bub_wechat/channel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import uuid
 from asyncio import Event
 from dataclasses import dataclass
@@ -16,7 +17,12 @@ from weixin_bot import IncomingMessage, WeixinBot
 from weixin_bot.api import MessageItemType, send_message
 from weixin_bot.types import MessageItem, MessageState, MessageType, SendMessageMessage
 
-TOKEN_PATH = Path.home() / ".bub/wechat_token.json"
+
+def get_token_path() -> Path:
+    """Return the WeChat token path under Bub's runtime data directory."""
+    bub_home = os.getenv("BUB_HOME")
+    home = Path(bub_home).expanduser() if bub_home else Path.home() / ".bub"
+    return home / "wechat_token.json"
 
 
 @dataclass
@@ -49,7 +55,7 @@ class WeChatChannel(Channel):
 
     def __init__(self, on_receive: MessageHandler) -> None:
         self.on_receive = on_receive
-        self.bot = WeixinBot(token_path=str(TOKEN_PATH))
+        self.bot = WeixinBot(token_path=str(get_token_path()))
         self.bot.on_message(self.process_message)
         self._ongoing_task: asyncio.Task | None = None
 

--- a/packages/bub-wechat/src/bub_wechat/channel.py
+++ b/packages/bub-wechat/src/bub_wechat/channel.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 import uuid
 from asyncio import Event
 from dataclasses import dataclass
 from pathlib import Path
 from typing import AsyncIterator, Literal
 
+import bub
 from bub.channels import Channel, ChannelMessage
 from bub.channels.message import MediaItem
 from bub.types import MessageHandler
@@ -20,9 +20,7 @@ from weixin_bot.types import MessageItem, MessageState, MessageType, SendMessage
 
 def get_token_path() -> Path:
     """Return the WeChat token path under Bub's runtime data directory."""
-    bub_home = os.getenv("BUB_HOME")
-    home = Path(bub_home).expanduser() if bub_home else Path.home() / ".bub"
-    return home / "wechat_token.json"
+    return bub.home / "wechat_token.json"
 
 
 @dataclass

--- a/packages/bub-wechat/src/bub_wechat/plugin.py
+++ b/packages/bub-wechat/src/bub_wechat/plugin.py
@@ -5,7 +5,7 @@ from bub.channels import Channel
 from bub.tools import ToolContext
 from bub.types import MessageHandler
 
-from bub_wechat.channel import TOKEN_PATH, OutgoingMessage, WeChatChannel
+from bub_wechat.channel import OutgoingMessage, WeChatChannel, get_token_path
 
 
 @auth_app.command()
@@ -13,7 +13,7 @@ def wechat():
     """Login to WeChat agent account."""
     from weixin_bot import WeixinBot
 
-    bot = WeixinBot(token_path=str(TOKEN_PATH))
+    bot = WeixinBot(token_path=str(get_token_path()))
     bot.login()
     typer.echo("Login successful! You can now start the Bub agent with WeChat channel.")
 

--- a/packages/bub-wechat/tests/test_channel.py
+++ b/packages/bub-wechat/tests/test_channel.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from bub_wechat.channel import get_token_path
+
+
+def test_token_path_uses_bub_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("BUB_HOME", str(tmp_path))
+
+    assert get_token_path() == tmp_path / "wechat_token.json"
+
+
+def test_token_path_defaults_to_dot_bub(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("BUB_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert get_token_path() == tmp_path / ".bub" / "wechat_token.json"

--- a/packages/bub-wechat/tests/test_channel.py
+++ b/packages/bub-wechat/tests/test_channel.py
@@ -1,16 +1,11 @@
 from pathlib import Path
 
+import bub
+
 from bub_wechat.channel import get_token_path
 
 
 def test_token_path_uses_bub_home(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("BUB_HOME", str(tmp_path))
+    monkeypatch.setattr(bub, "home", tmp_path)
 
     assert get_token_path() == tmp_path / "wechat_token.json"
-
-
-def test_token_path_defaults_to_dot_bub(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.delenv("BUB_HOME", raising=False)
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-
-    assert get_token_path() == tmp_path / ".bub" / "wechat_token.json"


### PR DESCRIPTION
## Summary

- resolve the WeChat token path from `BUB_HOME`
- preserve `~/.bub/wechat_token.json` as the fallback when `BUB_HOME` is unset
- document the token location
- add coverage for configured and default paths

## Why

Bub's Docker deployment mounts its persistent runtime directory at `/data` and sets `BUB_HOME=/data`. The WeChat plugin previously hard-coded the token under `Path.home() / ".bub"`, so container recreation discarded the login even though `/data/wechat_token.json` persisted.

## Verification

- `uv run ruff check packages/bub-wechat`
- `uv run --group test pytest -q packages/bub-wechat/tests` (2 passed)
