### PR TITLE
docs: remove obsolete pinning notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # bub-contrib
 
-> We are actively working on version 0.4.0. Until then, please pin [Bub 0.3.9 on PyPI](https://pypi.org/project/bub/0.3.9/) or [Bub@e5d8ceb](https://github.com/bubbuild/bub/tree/e5d8ceb3b30105e0d50e872be7d6ae6fb4066236) .
-
 Some contrib packages for the `bub` ecosystem.
 
 ## Plugin Discovery


### PR DESCRIPTION
## Summary

- remove the obsolete README notice that asks users to pin Bub 0.3.9 or commit `e5d8ceb`
- leave the package catalog and current installation example unchanged

## Why

The notice no longer reflects current Bub installation guidance and sends contrib users to an old release or commit.

## Validation

- `git diff --check` passed
- the repository contains no dedicated Markdown build or lint target