### PR TITLE
fix(web-search): handle non-json content-type from ollama api

### DIFF
--- a/packages/bub-web-search/src/bub_web_search/ollama.py
+++ b/packages/bub-web-search/src/bub_web_search/ollama.py
@@ -31,7 +31,7 @@ async def search(query: str, max_results: int, settings: WebSearchSettings) -> s
                 },
             ) as response,
         ):
-            data = await response.json()
+            data = await response.json(content_type=None)
     except aiohttp.ClientError as exc:
         return f"HTTP error: {exc!s}"
     except json.JSONDecodeError as exc:


### PR DESCRIPTION
Ollama's /api/web_search returns Content-Type: text/html instead of application/json, causing aiohttp response.json() to reject parsing. Add content_type=None to allow JSON decoding regardless of content-type.