### PR TITLE
bub-web-search 0.2.0: Jina search provider and web.read reader tool

### DIFF
--- a/packages/bub-web-search/README.md
+++ b/packages/bub-web-search/README.md
@@ -1,16 +1,31 @@
 # bub-web-search
 
-Provider-selectable web search tools for `bub`.
+Provider-selectable web tools for `bub`, covering two capabilities:
 
-## Providers
+- `web.search`: search the web, backed by one search provider
+- `web.read`: read a webpage as clean markdown, backed by one reader provider
 
-Set `BUB_SEARCH_PROVIDER` to enable exactly one search provider:
+Each capability has its own provider dimension, so they can be mixed freely
+(e.g. SearXNG for search, Jina for reading).
 
-- `ollama` registers `web.search`
-- `searxng` registers `searxng.search`
+## Search providers
 
-If the provider is unset or its required configuration is missing, neither tool is
-registered.
+Set `BUB_SEARCH_PROVIDER` (or `provider` in the `web-search:` config section)
+to enable exactly one search provider:
+
+- `ollama`
+- `searxng`
+- `jina`
+
+If the provider is unset it is inferred from which provider-specific
+configuration is present. If nothing resolves, `web.search` is not registered.
+
+## Reader providers
+
+There is no explicit reader selector: `web.read` is enabled by configuring a
+reader-capable platform. Currently that means a `jina_api_key` (Jina Reader);
+without one, `web.read` is not registered. A selector field will only be
+introduced once more than one reader platform exists.
 
 ## Installation
 
@@ -34,6 +49,44 @@ Optional:
   - Default: `https://ollama.com/api`
 
 The `web.search` tool accepts `query` and `max_results`.
+
+## Jina
+
+Required:
+
+- `BUB_SEARCH_PROVIDER=jina` for search; `BUB_SEARCH_JINA_API_KEY` alone
+  already enables the `web.read` reader
+- `BUB_SEARCH_JINA_API_KEY`
+
+Optional:
+
+- `BUB_SEARCH_JINA_SEARCH_BASE`
+  - Default: `https://s.jina.ai`
+- `BUB_SEARCH_JINA_READER_BASE`
+  - Default: `https://r.jina.ai`
+- `BUB_SEARCH_JINA_TIMEOUT_SECONDS`
+  - Default: `30`
+
+The `web.search` tool accepts `query`. The `web.read` tool accepts `url` and
+returns the page content as markdown.
+
+All settings can also be written to the `web-search:` section of the Bub
+config file, e.g.:
+
+```yaml
+web-search:
+  provider: jina
+  jina_api_key: jina_...
+```
+
+or mixing platforms per capability (SearXNG searches, Jina reads):
+
+```yaml
+web-search:
+  provider: searxng
+  searxng_base_url: https://searx.example.com
+  jina_api_key: jina_...
+```
 
 ## SearXNG
 

--- a/packages/bub-web-search/pyproject.toml
+++ b/packages/bub-web-search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bub-web-search"
-version = "0.1.0"
+version = "0.2.0"
 description = "Web search tools for Bub"
 readme = "README.md"
 authors = [

--- a/packages/bub-web-search/src/bub_web_search/config.py
+++ b/packages/bub-web-search/src/bub_web_search/config.py
@@ -7,6 +7,9 @@ DEFAULT_OLLAMA_API_BASE = "https://ollama.com/api"
 DEFAULT_SEARXNG_TIMEOUT_SECONDS = 10
 DEFAULT_SEARXNG_SAFE_SEARCH = 1
 DEFAULT_SEARXNG_USER_AGENT = "bub-web-search/1.0"
+DEFAULT_JINA_SEARCH_BASE = "https://s.jina.ai"
+DEFAULT_JINA_READER_BASE = "https://r.jina.ai"
+DEFAULT_JINA_TIMEOUT_SECONDS = 30
 
 
 @bub.config(name="web-search")
@@ -18,10 +21,15 @@ class WebSearchSettings(bub.Settings):
         extra="ignore",
     )
 
-    provider: Literal["ollama", "searxng"] | None = None
+    provider: Literal["ollama", "searxng", "jina"] | None = None
 
     ollama_api_key: str | None = None
     ollama_api_base: str = DEFAULT_OLLAMA_API_BASE
+
+    jina_api_key: str | None = None
+    jina_search_base: str = DEFAULT_JINA_SEARCH_BASE
+    jina_reader_base: str = DEFAULT_JINA_READER_BASE
+    jina_timeout_seconds: int = DEFAULT_JINA_TIMEOUT_SECONDS
 
     searxng_base_url: str | None = None
     searxng_timeout_seconds: int = DEFAULT_SEARXNG_TIMEOUT_SECONDS
@@ -32,14 +40,20 @@ class WebSearchSettings(bub.Settings):
     searxng_auth_value: str | None = None
 
     @property
-    def resolved_provider(self) -> Literal["ollama", "searxng"] | None:
+    def resolved_provider(self) -> Literal["ollama", "searxng", "jina"] | None:
         if self.provider is not None:
             return self.provider
         if self.ollama_api_key:
             return "ollama"
         if self.searxng_base_url:
             return "searxng"
+        if self.jina_api_key:
+            return "jina"
         return None
+
+    @property
+    def resolved_jina_timeout_seconds(self) -> int:
+        return max(1, self.jina_timeout_seconds)
 
     @property
     def resolved_searxng_base_url(self) -> str | None:

--- a/packages/bub-web-search/src/bub_web_search/jina.py
+++ b/packages/bub-web-search/src/bub_web_search/jina.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from bub_web_search.config import WebSearchSettings
+
+WEB_USER_AGENT = "bub-web-search/1.0"
+MAX_ERROR_BODY_CHARS = 500
+
+
+def reader_url(base: str, url: str) -> str:
+    base = base.strip().rstrip("/")
+    target = url.strip()
+    if target.startswith(f"{base}/"):
+        return target
+    return f"{base}/{target}"
+
+
+async def _request(
+    endpoint: str,
+    *,
+    settings: WebSearchSettings,
+    extra_headers: dict[str, str] | None = None,
+) -> str:
+    import aiohttp
+
+    api_key = settings.jina_api_key
+    if not api_key:
+        return "error: jina api key is not configured"
+
+    headers = {
+        "Accept": "*/*",
+        "User-Agent": WEB_USER_AGENT,
+        "Authorization": f"Bearer {api_key}",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+
+    try:
+        async with (
+            aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(
+                    total=settings.resolved_jina_timeout_seconds
+                )
+            ) as session,
+            session.get(endpoint, headers=headers) as response,
+        ):
+            body = await response.text()
+            if response.status != 200:
+                snippet = body[:MAX_ERROR_BODY_CHARS]
+                return f"error: jina returned status {response.status}: {snippet}"
+    except TimeoutError:
+        return "error: jina request timed out"
+    except aiohttp.ClientError as exc:
+        return f"HTTP error: {exc!s}"
+
+    return body.strip() or "none"
+
+
+async def search(*, query: str, settings: WebSearchSettings) -> str:
+    base = settings.jina_search_base.strip().rstrip("/")
+    if not base:
+        return "error: invalid jina search base url"
+    endpoint = f"{base}/?q={quote(query)}"
+    # "no-content" keeps the SERP compact: titles, URLs and snippets only.
+    return await _request(
+        endpoint, settings=settings, extra_headers={"X-Respond-With": "no-content"}
+    )
+
+
+async def read(*, url: str, settings: WebSearchSettings) -> str:
+    target = url.strip()
+    if not target:
+        return "error: url must not be blank"
+    return await _request(
+        reader_url(settings.jina_reader_base, target), settings=settings
+    )

--- a/packages/bub-web-search/src/bub_web_search/tools.py
+++ b/packages/bub-web-search/src/bub_web_search/tools.py
@@ -8,8 +8,10 @@ from bub import hookimpl, tool
 from bub import inquirer as bub_inquirer
 from bub.tools import REGISTRY
 
-from bub_web_search import ollama, searxng
+from bub_web_search import jina, ollama, searxng
 from bub_web_search.config import (
+    DEFAULT_JINA_READER_BASE,
+    DEFAULT_JINA_SEARCH_BASE,
     DEFAULT_OLLAMA_API_BASE,
     DEFAULT_SEARXNG_SAFE_SEARCH,
     DEFAULT_SEARXNG_TIMEOUT_SECONDS,
@@ -21,8 +23,8 @@ if TYPE_CHECKING:
     from bub.tools import Tool
 
 SEARCH_TOOL_NAME = "web.search"
+READ_TOOL_NAME = "web.read"
 CONFIG_NAME = "web-search"
-PROVIDERS = ["ollama", "searxng"]
 
 
 @hookimpl
@@ -43,9 +45,12 @@ def onboard_config(current_config: dict[str, Any]) -> dict[str, Any] | None:
     )
     if provider == "ollama":
         provider_config = _onboard_ollama(current)
+    elif provider == "jina":
+        provider_config = _onboard_jina(current)
     else:
         provider_config = _onboard_searxng(current)
-    return {CONFIG_NAME: {"provider": provider, **provider_config}}
+    reader_config = _onboard_reader(current, provider_config)
+    return {CONFIG_NAME: {"provider": provider, **provider_config, **reader_config}}
 
 
 def _current_provider(current: dict[str, Any]) -> str:
@@ -56,6 +61,8 @@ def _current_provider(current: dict[str, Any]) -> str:
         return "ollama"
     if current.get("searxng_base_url"):
         return "searxng"
+    if current.get("jina_api_key"):
+        return "jina"
     return "ollama"
 
 
@@ -68,6 +75,43 @@ def _onboard_ollama(current: dict[str, Any]) -> dict[str, Any]:
             default=str(current.get("ollama_api_base") or DEFAULT_OLLAMA_API_BASE),
         ),
     }
+
+
+def _onboard_jina(current: dict[str, Any]) -> dict[str, Any]:
+    api_key = bub_inquirer.ask_secret("Jina API key")
+    return {
+        "jina_api_key": api_key or str(current.get("jina_api_key") or ""),
+        "jina_search_base": bub_inquirer.ask_text(
+            "Jina search base URL",
+            default=str(current.get("jina_search_base") or DEFAULT_JINA_SEARCH_BASE),
+        ),
+        "jina_reader_base": bub_inquirer.ask_text(
+            "Jina reader base URL",
+            default=str(current.get("jina_reader_base") or DEFAULT_JINA_READER_BASE),
+        ),
+    }
+
+
+def _onboard_reader(
+    current: dict[str, Any], provider_config: dict[str, Any]
+) -> dict[str, Any]:
+    has_jina_key = bool(provider_config.get("jina_api_key") or current.get("jina_api_key"))
+    enable = bub_inquirer.ask_confirm(
+        "Enable the web.read tool (Jina Reader)",
+        default=has_jina_key,
+    )
+    if not enable:
+        return {}
+    reader_config: dict[str, Any] = {}
+    if not provider_config.get("jina_api_key"):
+        api_key = bub_inquirer.ask_secret("Jina API key")
+        reader_config["jina_api_key"] = api_key or str(current.get("jina_api_key") or "")
+    if "jina_reader_base" not in provider_config:
+        reader_config["jina_reader_base"] = bub_inquirer.ask_text(
+            "Jina reader base URL",
+            default=str(current.get("jina_reader_base") or DEFAULT_JINA_READER_BASE),
+        )
+    return reader_config
 
 
 def _onboard_searxng(current: dict[str, Any]) -> dict[str, Any]:
@@ -122,15 +166,20 @@ def register_tools(
         WebSearchSettings
     ),
 ) -> Tool | None:
+    """Register one platform per capability; no match means no tool."""
     REGISTRY.pop(SEARCH_TOOL_NAME, None)
+    REGISTRY.pop(READ_TOOL_NAME, None)
 
     settings = settings_factory()
-    provider = settings.resolved_provider
-    if provider == "ollama":
-        return _register_ollama_tool(settings)
-    elif provider == "searxng":
-        return _register_searxng_tool(settings)
-    return None
+    search_tool: Tool | None = None
+    if registrar := SEARCH_REGISTRARS.get(settings.resolved_provider):
+        search_tool = registrar(settings)
+    # Readers have no selector field: each registrar guards on its own
+    # platform configuration, and the first configured one wins.
+    for reader_registrar in READER_REGISTRARS.values():
+        if reader_registrar(settings):
+            break
+    return search_tool
 
 
 def _register_ollama_tool(settings: WebSearchSettings) -> Tool | None:
@@ -147,6 +196,30 @@ def _register_ollama_tool(settings: WebSearchSettings) -> Tool | None:
     return web_search_ollama
 
 
+def _register_jina_search_tool(settings: WebSearchSettings) -> Tool | None:
+    if not settings.jina_api_key:
+        return None
+
+    @tool(name=SEARCH_TOOL_NAME)
+    async def web_search_jina(query: str) -> str:
+        """Search the web with Jina Search and return SERP results."""
+        return await jina.search(query=query, settings=settings)
+
+    return web_search_jina
+
+
+def _register_jina_read_tool(settings: WebSearchSettings) -> Tool | None:
+    if not settings.jina_api_key:
+        return None
+
+    @tool(name=READ_TOOL_NAME)
+    async def web_read_jina(url: str) -> str:
+        """Read a webpage and return its main content as clean markdown."""
+        return await jina.read(url=url, settings=settings)
+
+    return web_read_jina
+
+
 def _register_searxng_tool(settings: WebSearchSettings) -> Tool | None:
     if settings.resolved_searxng_base_url is None:
         return None
@@ -160,6 +233,20 @@ def _register_searxng_tool(settings: WebSearchSettings) -> Tool | None:
         return await searxng.search(param=param, settings=settings)
 
     return searxng_search
+
+
+# To add a platform, implement a registrar above and list it here. The
+# capability tables below are the single source of truth for both tool
+# registration and onboarding choices.
+SEARCH_REGISTRARS: dict[str | None, Callable[[WebSearchSettings], Tool | None]] = {
+    "ollama": _register_ollama_tool,
+    "searxng": _register_searxng_tool,
+    "jina": _register_jina_search_tool,
+}
+READER_REGISTRARS: dict[str | None, Callable[[WebSearchSettings], Tool | None]] = {
+    "jina": _register_jina_read_tool,
+}
+PROVIDERS = [name for name in SEARCH_REGISTRARS if name]
 
 
 register_tools()

--- a/packages/bub-web-search/tests/test_jina.py
+++ b/packages/bub-web-search/tests/test_jina.py
@@ -1,0 +1,38 @@
+from bub_web_search import jina
+from bub_web_search.config import WebSearchSettings
+
+
+def test_reader_url_prefixes_target() -> None:
+    assert (
+        jina.reader_url("https://r.jina.ai", "https://example.com/page")
+        == "https://r.jina.ai/https://example.com/page"
+    )
+
+
+def test_reader_url_keeps_already_prefixed_target() -> None:
+    prefixed = "https://r.jina.ai/https://example.com/page"
+    assert jina.reader_url("https://r.jina.ai/", prefixed) == prefixed
+
+
+async def test_search_requires_api_key() -> None:
+    result = await jina.search(query="bub", settings=WebSearchSettings())
+    assert result == "error: jina api key is not configured"
+
+
+async def test_read_requires_api_key() -> None:
+    result = await jina.read(
+        url="https://example.com", settings=WebSearchSettings()
+    )
+    assert result == "error: jina api key is not configured"
+
+
+async def test_read_rejects_blank_url() -> None:
+    result = await jina.read(url="  ", settings=WebSearchSettings(jina_api_key="k"))
+    assert result == "error: url must not be blank"
+
+
+async def test_search_rejects_blank_base() -> None:
+    settings = WebSearchSettings(jina_api_key="k", jina_search_base="  ")
+    assert await jina.search(query="bub", settings=settings) == (
+        "error: invalid jina search base url"
+    )

--- a/packages/bub-web-search/tests/test_tools.py
+++ b/packages/bub-web-search/tests/test_tools.py
@@ -5,7 +5,10 @@ from bub_web_search.config import WebSearchSettings
 
 
 def test_onboard_config_collects_ollama_settings(monkeypatch) -> None:
-    monkeypatch.setattr(tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: True)
+    confirm_answers = iter([True, False])
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: next(confirm_answers)
+    )
     monkeypatch.setattr(
         tools.bub_inquirer, "ask_select", lambda *args, **kwargs: "ollama"
     )
@@ -40,7 +43,10 @@ def test_onboard_config_collects_searxng_settings(monkeypatch) -> None:
         ]
     )
     select_answers = iter(["searxng", "2"])
-    monkeypatch.setattr(tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: True)
+    confirm_answers = iter([True, False])
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: next(confirm_answers)
+    )
     monkeypatch.setattr(
         tools.bub_inquirer,
         "ask_select",
@@ -112,8 +118,55 @@ def test_onboard_config_preserves_existing_secrets_and_safe_search(monkeypatch) 
     assert result["web-search"]["searxng_auth_value"] == "existing-secret"
 
 
+def test_onboard_config_collects_jina_settings(monkeypatch) -> None:
+    text_answers = iter(["https://s.jina.example", "https://r.jina.example"])
+    monkeypatch.setattr(tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tools.bub_inquirer, "ask_select", lambda *args, **kwargs: "jina")
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_secret", lambda *args, **kwargs: "jina-secret"
+    )
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_text", lambda *args, **kwargs: next(text_answers)
+    )
+
+    assert tools.onboard_config({}) == {
+        "web-search": {
+            "provider": "jina",
+            "jina_api_key": "jina-secret",
+            "jina_search_base": "https://s.jina.example",
+            "jina_reader_base": "https://r.jina.example",
+        }
+    }
+
+
+def test_onboard_config_collects_reader_with_other_provider(monkeypatch) -> None:
+    text_answers = iter(["https://ollama.example/api", "https://r.jina.example"])
+    secret_answers = iter(["ollama-secret", "jina-secret"])
+    monkeypatch.setattr(tools.bub_inquirer, "ask_confirm", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_select", lambda *args, **kwargs: "ollama"
+    )
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_secret", lambda *args, **kwargs: next(secret_answers)
+    )
+    monkeypatch.setattr(
+        tools.bub_inquirer, "ask_text", lambda *args, **kwargs: next(text_answers)
+    )
+
+    assert tools.onboard_config({}) == {
+        "web-search": {
+            "provider": "ollama",
+            "ollama_api_key": "ollama-secret",
+            "ollama_api_base": "https://ollama.example/api",
+            "jina_api_key": "jina-secret",
+            "jina_reader_base": "https://r.jina.example",
+        }
+    }
+
+
 def teardown_function() -> None:
     REGISTRY.pop(tools.SEARCH_TOOL_NAME, None)
+    REGISTRY.pop(tools.READ_TOOL_NAME, None)
 
 
 def test_register_tools_skips_unconfigured_provider() -> None:
@@ -161,6 +214,58 @@ def test_register_tools_enables_searxng_tool() -> None:
         "Search a configured SearXNG instance and return concise web results."
     )
     assert "categories" in tool_instance.parameters["properties"]
+
+
+def test_register_tools_enables_jina_tools() -> None:
+    tool_instance = tools.register_tools(
+        lambda: WebSearchSettings(
+            provider="jina",
+            jina_api_key="secret",
+        )
+    )
+
+    assert tool_instance is not None
+    assert REGISTRY[tools.SEARCH_TOOL_NAME] is tool_instance
+    assert (
+        tool_instance.description
+        == "Search the web with Jina Search and return SERP results."
+    )
+    assert tools.READ_TOOL_NAME in REGISTRY
+
+
+def test_register_tools_registers_read_tool_alongside_other_provider() -> None:
+    tool_instance = tools.register_tools(
+        lambda: WebSearchSettings(
+            provider="searxng",
+            searxng_base_url="https://search.example.com",
+            jina_api_key="secret",
+        )
+    )
+
+    assert tool_instance is not None
+    assert "categories" in tool_instance.parameters["properties"]
+    assert tools.READ_TOOL_NAME in REGISTRY
+
+
+def test_register_tools_skips_read_tool_without_jina_key() -> None:
+    tools.register_tools(
+        lambda: WebSearchSettings(
+            provider="ollama",
+            ollama_api_key="secret",
+        )
+    )
+
+    assert tools.READ_TOOL_NAME not in REGISTRY
+
+
+def test_register_tools_infers_jina_provider() -> None:
+    tool_instance = tools.register_tools(
+        lambda: WebSearchSettings(jina_api_key="secret")
+    )
+
+    assert tool_instance is not None
+    assert REGISTRY[tools.SEARCH_TOOL_NAME] is tool_instance
+    assert tools.READ_TOOL_NAME in REGISTRY
 
 
 def test_register_tools_infers_provider_from_configuration() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -799,7 +799,7 @@ requires-dist = [
 
 [[package]]
 name = "bub-web-search"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/bub-web-search" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds **Jina** (`s.jina.ai`) as a third `web.search` provider alongside ollama and searxng.
- Introduces a second capability: **`web.read`** (Jina Reader, `r.jina.ai`) returns the main content of a webpage as clean markdown — complementing the raw-HTML `web.fetch` builtin, which floods context with markup on real pages and cannot handle client-side rendered sites.
- Readers intentionally have **no selector field**: each reader registrar guards on its own platform configuration (`jina_api_key` present ⇒ `web.read` registered). This keeps the config surface unchanged and allows mixing platforms per capability, e.g. SearXNG for search + Jina for reading. A selector can be introduced later if a second reader platform creates real ambiguity.
- Search and reader registration are now both table-driven (`SEARCH_REGISTRARS` / `READER_REGISTRARS`); adding a platform is one module plus one registrar entry. No behavior change for existing ollama/searxng configs.
- `bub onboard` asks whether to enable `web.read` after the search provider step.
- Version bumped 0.1.0 → 0.2.0.

Example config:

```yaml
web-search:
  provider: jina        # or searxng/ollama; web.read works alongside any of them
  jina_api_key: jina_...
```

## Test plan

- [x] 27 unit tests pass (`uv run pytest packages/bub-web-search/tests`), covering provider/reader registration matrices, onboarding flows, and jina request guards.
- [x] Verified live in a bub gateway (QQ channel): model chained `web.search` → `web.read` → reply autonomously; both tools hit the real Jina endpoints successfully.

Made with [Cursor](https://cursor.com)